### PR TITLE
Redesign authenticated area with show routes and card grid index pages

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -15,18 +15,37 @@ class DashboardController extends Controller
         $recentWorksheets = $user->worksheets()
             ->latest()
             ->limit(5)
-            ->get(['id', 'topic', 'discipline', 'created_at']);
+            ->get(['id', 'topic', 'discipline', 'created_at'])
+            ->map(fn ($ws) => [
+                'id' => $ws->id,
+                'type' => 'worksheet',
+                'title' => $ws->topic,
+                'discipline' => $ws->discipline,
+                'created_at' => $ws->created_at->toIso8601String(),
+            ]);
 
         $recentSummaries = $user->summaries()
             ->latest()
             ->limit(5)
-            ->get(['id', 'title', 'discipline', 'created_at']);
+            ->get(['id', 'title', 'discipline', 'created_at'])
+            ->map(fn ($s) => [
+                'id' => $s->id,
+                'type' => 'summary',
+                'title' => $s->title,
+                'discipline' => $s->discipline,
+                'created_at' => $s->created_at->toIso8601String(),
+            ]);
+
+        $recentActivity = $recentWorksheets
+            ->merge($recentSummaries)
+            ->sortByDesc('created_at')
+            ->take(8)
+            ->values();
 
         return Inertia::render('dashboard', [
             'worksheetCount' => $user->worksheets()->count(),
-            'recentWorksheets' => $recentWorksheets,
             'summaryCount' => $user->summaries()->count(),
-            'recentSummaries' => $recentSummaries,
+            'recentActivity' => $recentActivity,
         ]);
     }
 }

--- a/app/Http/Controllers/SummaryController.php
+++ b/app/Http/Controllers/SummaryController.php
@@ -29,20 +29,24 @@ class SummaryController extends Controller
 
     public function index(Request $request): Response
     {
-        $summaryId = $request->integer('summary');
-
-        $summary = $request->user()
+        $summaries = $request->user()
             ->summaries()
-            ->when($summaryId, fn ($query) => $query->whereKey($summaryId))
             ->latest()
-            ->first();
+            ->paginate(12, ['id', 'title', 'discipline', 'topic', 'source_file_name', 'created_at']);
 
-        if ($summaryId && ! $summary) {
+        return Inertia::render('summaries/index', [
+            'summaries' => $summaries,
+        ]);
+    }
+
+    public function show(Request $request, Summary $summary): Response
+    {
+        if ($summary->user_id !== $request->user()?->id) {
             abort(HttpResponse::HTTP_NOT_FOUND);
         }
 
-        return Inertia::render('summaries/index', [
-            'summary' => $summary ? $this->presentSummary($summary) : null,
+        return Inertia::render('summaries/show', [
+            'summary' => $this->presentSummary($summary),
         ]);
     }
 
@@ -106,7 +110,7 @@ class SummaryController extends Controller
             'content' => $content,
         ]);
 
-        return to_route('summaries.index', ['summary' => $summary->id]);
+        return to_route('summaries.show', ['summary' => $summary->id]);
     }
 
     public function detectPageCount(Request $request): JsonResponse
@@ -131,7 +135,7 @@ class SummaryController extends Controller
 
         $summary->increment('share_link_copies_count');
 
-        return to_route('summaries.index', ['summary' => $summary->id]);
+        return to_route('summaries.show', ['summary' => $summary->id]);
     }
 
     public function destroy(Request $request, Summary $summary): RedirectResponse

--- a/app/Http/Controllers/WorksheetController.php
+++ b/app/Http/Controllers/WorksheetController.php
@@ -28,20 +28,24 @@ class WorksheetController extends Controller
 
     public function index(Request $request): Response
     {
-        $worksheetId = $request->integer('worksheet');
-
-        $worksheet = $request->user()
+        $worksheets = $request->user()
             ->worksheets()
-            ->when($worksheetId, fn ($query) => $query->whereKey($worksheetId))
             ->latest()
-            ->first();
+            ->paginate(12, ['id', 'discipline', 'topic', 'difficulty', 'education_level', 'question_count', 'created_at']);
 
-        if ($worksheetId && ! $worksheet) {
+        return Inertia::render('worksheets/index', [
+            'worksheets' => $worksheets,
+        ]);
+    }
+
+    public function show(Request $request, Worksheet $worksheet): Response
+    {
+        if ($worksheet->user_id !== $request->user()?->id) {
             abort(HttpResponse::HTTP_NOT_FOUND);
         }
 
-        return Inertia::render('worksheets/index', [
-            'worksheet' => $worksheet ? $this->presentWorksheet($worksheet) : null,
+        return Inertia::render('worksheets/show', [
+            'worksheet' => $this->presentWorksheet($worksheet),
         ]);
     }
 
@@ -122,7 +126,7 @@ class WorksheetController extends Controller
             'content' => $content,
         ]);
 
-        return to_route('worksheets.index', ['worksheet' => $worksheet->id]);
+        return to_route('worksheets.show', ['worksheet' => $worksheet->id]);
     }
 
     public function trackShareClick(Request $request, Worksheet $worksheet): RedirectResponse
@@ -133,7 +137,7 @@ class WorksheetController extends Controller
 
         $worksheet->increment('share_link_copies_count');
 
-        return to_route('worksheets.index', ['worksheet' => $worksheet->id]);
+        return to_route('worksheets.show', ['worksheet' => $worksheet->id]);
     }
 
     public function destroy(Request $request, Worksheet $worksheet): RedirectResponse

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Middleware;
 
-use App\Models\Summary;
-use App\Models\Worksheet;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
@@ -47,34 +45,6 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
             ],
-            'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
-            'worksheetHistory' => $request->user()
-                ? Worksheet::query()
-                    ->whereBelongsTo($request->user())
-                    ->latest()
-                    ->limit(25)
-                    ->get(['id', 'discipline', 'topic', 'created_at'])
-                    ->map(fn (Worksheet $worksheet) => [
-                        'id' => $worksheet->id,
-                        'discipline' => $worksheet->discipline,
-                        'topic' => $worksheet->topic,
-                        'created_at' => $worksheet->created_at->toIso8601String(),
-                    ])
-                : [],
-            'summaryHistory' => $request->user()
-                ? Summary::query()
-                    ->whereBelongsTo($request->user())
-                    ->latest()
-                    ->limit(25)
-                    ->get(['id', 'title', 'discipline', 'topic', 'created_at'])
-                    ->map(fn (Summary $summary) => [
-                        'id' => $summary->id,
-                        'title' => $summary->title,
-                        'discipline' => $summary->discipline,
-                        'topic' => $summary->topic,
-                        'created_at' => $summary->created_at->toIso8601String(),
-                    ])
-                : [],
         ];
     }
 }

--- a/resources/js/components/app-shell.tsx
+++ b/resources/js/components/app-shell.tsx
@@ -1,6 +1,4 @@
 import { SidebarProvider } from '@/components/ui/sidebar';
-import { SharedData } from '@/types';
-import { usePage } from '@inertiajs/react';
 
 interface AppShellProps {
     children: React.ReactNode;
@@ -8,13 +6,11 @@ interface AppShellProps {
 }
 
 export function AppShell({ children, variant = 'header' }: AppShellProps) {
-    const isOpen = usePage<SharedData>().props.sidebarOpen;
-
     if (variant === 'header') {
         return (
             <div className="flex min-h-screen w-full flex-col">{children}</div>
         );
     }
 
-    return <SidebarProvider defaultOpen={isOpen}>{children}</SidebarProvider>;
+    return <SidebarProvider defaultOpen={true}>{children}</SidebarProvider>;
 }

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,12 +1,4 @@
 import { NavUser } from '@/components/nav-user';
-import { Button } from '@/components/ui/button';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
 import {
     Sidebar,
     SidebarContent,
@@ -19,34 +11,28 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
-import { cn, resolveUrl } from '@/lib/utils';
+import { resolveUrl } from '@/lib/utils';
 import { dashboard } from '@/routes';
 import {
     create as worksheetsCreate,
-    destroy as worksheetsDestroy,
     index as worksheetsIndex,
 } from '@/routes/worksheets';
 import {
     create as summariesCreate,
-    destroy as summariesDestroy,
     index as summariesIndex,
 } from '@/routes/summaries';
 import { dashboard as adminDashboard } from '@/routes/admin';
 import { type SharedData } from '@/types';
-import { Link, router, usePage } from '@inertiajs/react';
+import { Link, usePage } from '@inertiajs/react';
 import {
     Brain,
     ClipboardList,
     FileText,
     LayoutDashboard,
-    MoreHorizontal,
     Plus,
-    Search,
     Shield,
     Target,
-    Trash2,
 } from 'lucide-react';
-import { useMemo, useState } from 'react';
 import AppLogo from './app-logo';
 
 const comingSoonItems = [
@@ -62,64 +48,7 @@ const comingSoonItems = [
 
 export function AppSidebar() {
     const { props, url } = usePage<SharedData>();
-    const worksheetHistory = useMemo(
-        () => props.worksheetHistory ?? [],
-        [props.worksheetHistory],
-    );
-    const summaryHistory = useMemo(
-        () => props.summaryHistory ?? [],
-        [props.summaryHistory],
-    );
     const isAdmin = Boolean(props.auth?.user?.is_admin);
-    const [worksheetSearch, setWorksheetSearch] = useState('');
-    const [summarySearch, setSummarySearch] = useState('');
-
-    const handleRemoveWorksheet = (worksheetId: number) => {
-        if (!window.confirm('Deseja remover esta ficha?')) {
-            return;
-        }
-
-        router.delete(worksheetsDestroy(worksheetId).url, {
-            preserveScroll: true,
-        });
-    };
-
-    const handleRemoveSummary = (summaryId: number) => {
-        if (!window.confirm('Deseja remover este resumo?')) {
-            return;
-        }
-
-        router.delete(summariesDestroy(summaryId).url, {
-            preserveScroll: true,
-        });
-    };
-
-    const filteredWorksheetHistory = useMemo(() => {
-        const term = worksheetSearch.trim().toLowerCase();
-        if (!term) {
-            return worksheetHistory;
-        }
-
-        return worksheetHistory.filter(
-            (item) =>
-                item.topic.toLowerCase().includes(term) ||
-                item.discipline.toLowerCase().includes(term),
-        );
-    }, [worksheetHistory, worksheetSearch]);
-
-    const filteredSummaryHistory = useMemo(() => {
-        const term = summarySearch.trim().toLowerCase();
-        if (!term) {
-            return summaryHistory;
-        }
-
-        return summaryHistory.filter(
-            (item) =>
-                item.title.toLowerCase().includes(term) ||
-                item.topic.toLowerCase().includes(term) ||
-                item.discipline.toLowerCase().includes(term),
-        );
-    }, [summaryHistory, summarySearch]);
 
     return (
         <Sidebar collapsible="icon" variant="inset">
@@ -161,18 +90,12 @@ export function AppSidebar() {
                                     <span>Listas de exercícios</span>
                                 </Link>
                             </SidebarMenuButton>
-                        </SidebarMenuItem>
-                        <SidebarMenuItem>
-                            <Button
-                                asChild
-                                size="sm"
-                                className="my-1 w-full justify-start gap-2"
-                            >
+                            <SidebarMenuAction asChild>
                                 <Link href={worksheetsCreate()} prefetch>
                                     <Plus className="size-4" />
-                                    Nova lista
+                                    <span className="sr-only">Nova lista</span>
                                 </Link>
-                            </Button>
+                            </SidebarMenuAction>
                         </SidebarMenuItem>
                         <SidebarMenuItem>
                             <SidebarMenuButton
@@ -184,19 +107,12 @@ export function AppSidebar() {
                                     <span>Resumos</span>
                                 </Link>
                             </SidebarMenuButton>
-                        </SidebarMenuItem>
-                        <SidebarMenuItem>
-                            <Button
-                                asChild
-                                size="sm"
-                                variant="outline"
-                                className="my-1 w-full justify-start gap-2"
-                            >
+                            <SidebarMenuAction asChild>
                                 <Link href={summariesCreate()} prefetch>
                                     <Plus className="size-4" />
-                                    Novo resumo
+                                    <span className="sr-only">Novo resumo</span>
                                 </Link>
-                            </Button>
+                            </SidebarMenuAction>
                         </SidebarMenuItem>
                     </SidebarMenu>
                 </SidebarGroup>
@@ -231,174 +147,6 @@ export function AppSidebar() {
                         </SidebarMenu>
                     </SidebarGroup>
                 )}
-
-                {/* Worksheet history */}
-                <SidebarGroup>
-                    <SidebarGroupLabel>
-                        <span>Histórico de listas</span>
-                    </SidebarGroupLabel>
-                    <div className="px-2 pb-2">
-                        <div className="flex items-center gap-2 rounded-md border border-input px-2 py-1.5 text-sm text-muted-foreground shadow-xs">
-                            <Search className="size-4 shrink-0" />
-                            <Input
-                                value={worksheetSearch}
-                                onChange={(event) => setWorksheetSearch(event.target.value)}
-                                placeholder="Buscar listas"
-                                className="h-7 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:ring-0"
-                            />
-                        </div>
-                    </div>
-                    <div className="space-y-1 px-2 pb-2">
-                        {filteredWorksheetHistory.length === 0 ? (
-                            <div className="rounded-md border border-dashed border-input px-3 py-4 text-sm text-muted-foreground">
-                                Nenhuma lista encontrada.
-                            </div>
-                        ) : (
-                            filteredWorksheetHistory.map((item) => (
-                                <SidebarMenuItem key={item.id}>
-                                    <SidebarMenuButton
-                                        asChild
-                                        className={cn(
-                                            'flex items-start gap-3 text-left',
-                                            resolveUrl(url).includes('fichas')
-                                                ? 'data-[active=true]:bg-accent data-[active=true]:text-foreground'
-                                                : '',
-                                        )}
-                                        isActive={
-                                            resolveUrl(url) ===
-                                            resolveUrl(
-                                                worksheetsIndex({
-                                                    query: { worksheet: item.id },
-                                                }),
-                                            )
-                                        }
-                                    >
-                                        <Link
-                                            href={worksheetsIndex({
-                                                query: { worksheet: item.id },
-                                            })}
-                                            prefetch
-                                        >
-                                            <div className="flex flex-col gap-0.5">
-                                                <span className="line-clamp-1 text-sm font-medium">
-                                                    {item.topic}
-                                                </span>
-                                                <span className="line-clamp-1 text-xs text-muted-foreground">
-                                                    {item.discipline}
-                                                </span>
-                                            </div>
-                                        </Link>
-                                    </SidebarMenuButton>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <SidebarMenuAction showOnHover>
-                                                <span className="sr-only">
-                                                    Opções da lista
-                                                </span>
-                                                <MoreHorizontal className="size-4" />
-                                            </SidebarMenuAction>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent align="end">
-                                            <DropdownMenuItem
-                                                variant="destructive"
-                                                onClick={() =>
-                                                    handleRemoveWorksheet(item.id)
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                                Remover lista
-                                            </DropdownMenuItem>
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
-                                </SidebarMenuItem>
-                            ))
-                        )}
-                    </div>
-                </SidebarGroup>
-
-                {/* Summary history */}
-                <SidebarGroup className="flex-1">
-                    <SidebarGroupLabel>
-                        <span>Histórico de resumos</span>
-                    </SidebarGroupLabel>
-                    <div className="px-2 pb-2">
-                        <div className="flex items-center gap-2 rounded-md border border-input px-2 py-1.5 text-sm text-muted-foreground shadow-xs">
-                            <Search className="size-4 shrink-0" />
-                            <Input
-                                value={summarySearch}
-                                onChange={(event) => setSummarySearch(event.target.value)}
-                                placeholder="Buscar resumos"
-                                className="h-7 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:ring-0"
-                            />
-                        </div>
-                    </div>
-                    <div className="flex-1 space-y-1 px-2 pb-2">
-                        {filteredSummaryHistory.length === 0 ? (
-                            <div className="rounded-md border border-dashed border-input px-3 py-4 text-sm text-muted-foreground">
-                                Nenhum resumo encontrado.
-                            </div>
-                        ) : (
-                            filteredSummaryHistory.map((item) => (
-                                <SidebarMenuItem key={item.id}>
-                                    <SidebarMenuButton
-                                        asChild
-                                        className={cn(
-                                            'flex items-start gap-3 text-left',
-                                            resolveUrl(url).includes('resumos')
-                                                ? 'data-[active=true]:bg-accent data-[active=true]:text-foreground'
-                                                : '',
-                                        )}
-                                        isActive={
-                                            resolveUrl(url) ===
-                                            resolveUrl(
-                                                summariesIndex({
-                                                    query: { summary: item.id },
-                                                }),
-                                            )
-                                        }
-                                    >
-                                        <Link
-                                            href={summariesIndex({
-                                                query: { summary: item.id },
-                                            })}
-                                            prefetch
-                                        >
-                                            <div className="flex flex-col gap-0.5">
-                                                <span className="line-clamp-1 text-sm font-medium">
-                                                    {item.title}
-                                                </span>
-                                                <span className="line-clamp-1 text-xs text-muted-foreground">
-                                                    {item.discipline}
-                                                </span>
-                                            </div>
-                                        </Link>
-                                    </SidebarMenuButton>
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            <SidebarMenuAction showOnHover>
-                                                <span className="sr-only">
-                                                    Opções do resumo
-                                                </span>
-                                                <MoreHorizontal className="size-4" />
-                                            </SidebarMenuAction>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent align="end">
-                                            <DropdownMenuItem
-                                                variant="destructive"
-                                                onClick={() =>
-                                                    handleRemoveSummary(item.id)
-                                                }
-                                            >
-                                                <Trash2 className="size-4" />
-                                                Remover resumo
-                                            </DropdownMenuItem>
-                                        </DropdownMenuContent>
-                                    </DropdownMenu>
-                                </SidebarMenuItem>
-                            ))
-                        )}
-                    </div>
-                </SidebarGroup>
             </SidebarContent>
 
             <SidebarFooter>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/app-layout';
-import { create as worksheetsCreate, index as worksheetsIndex } from '@/routes/worksheets';
-import { create as summariesCreate, index as summariesIndex } from '@/routes/summaries';
+import { create as worksheetsCreate, index as worksheetsIndex, show as worksheetsShow } from '@/routes/worksheets';
+import { create as summariesCreate, index as summariesIndex, show as summariesShow } from '@/routes/summaries';
 import { dashboard } from '@/routes';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/react';
@@ -20,21 +20,18 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
+type RecentActivityItem = {
+    id: number;
+    type: 'worksheet' | 'summary';
+    title: string;
+    discipline: string;
+    created_at: string;
+};
+
 type DashboardProps = SharedData & {
     worksheetCount: number;
-    recentWorksheets: {
-        id: number;
-        topic: string;
-        discipline: string;
-        created_at: string;
-    }[];
     summaryCount: number;
-    recentSummaries: {
-        id: number;
-        title: string;
-        discipline: string;
-        created_at: string;
-    }[];
+    recentActivity: RecentActivityItem[];
 };
 
 const tools = [
@@ -72,12 +69,12 @@ const tools = [
 
 export default function Dashboard({
     worksheetCount,
-    recentWorksheets,
     summaryCount,
-    recentSummaries,
+    recentActivity,
 }: DashboardProps) {
     const { auth } = usePage<SharedData>().props;
     const firstName = auth.user.name.split(' ')[0];
+    const totalCount = worksheetCount + summaryCount;
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -142,142 +139,104 @@ export default function Dashboard({
                     ))}
                 </div>
 
-                {/* Stats + recent worksheets */}
+                {/* Recent activity */}
                 <div className="flex flex-col gap-6">
                     <div className="flex items-center justify-between">
                         <h2 className="text-lg font-semibold">
-                            Suas listas
+                            Atividade recente
                         </h2>
-                        <Button asChild variant="outline" size="sm">
-                            <Link href={worksheetsIndex()} prefetch>
-                                Ver todas
-                            </Link>
-                        </Button>
+                        <div className="flex gap-2">
+                            <Button asChild variant="outline" size="sm">
+                                <Link href={worksheetsIndex()} prefetch>
+                                    Listas
+                                </Link>
+                            </Button>
+                            <Button asChild variant="outline" size="sm">
+                                <Link href={summariesIndex()} prefetch>
+                                    Resumos
+                                </Link>
+                            </Button>
+                        </div>
                     </div>
 
-                    {worksheetCount === 0 ? (
+                    {totalCount === 0 ? (
                         <div className="flex flex-col items-center gap-4 rounded-2xl border border-dashed bg-card p-10 text-center">
                             <div className="flex size-14 items-center justify-center rounded-2xl bg-muted">
                                 <ClipboardList className="size-7 text-muted-foreground" />
                             </div>
                             <div className="flex flex-col gap-1">
                                 <p className="text-sm font-semibold">
-                                    Nenhuma lista ainda
+                                    Nenhuma atividade ainda
                                 </p>
                                 <p className="text-xs text-muted-foreground">
-                                    Crie sua primeira lista de exercícios com IA.
+                                    Crie sua primeira lista ou resumo com IA.
                                 </p>
                             </div>
-                            <Button asChild size="sm">
-                                <Link href={worksheetsCreate()} prefetch>
-                                    <Plus className="mr-1 size-4" />
-                                    Criar primeira lista
-                                </Link>
-                            </Button>
+                            <div className="flex gap-2">
+                                <Button asChild size="sm">
+                                    <Link href={worksheetsCreate()} prefetch>
+                                        <Plus className="mr-1 size-4" />
+                                        Nova lista
+                                    </Link>
+                                </Button>
+                                <Button asChild size="sm" variant="outline">
+                                    <Link href={summariesCreate()} prefetch>
+                                        <Plus className="mr-1 size-4" />
+                                        Novo resumo
+                                    </Link>
+                                </Button>
+                            </div>
                         </div>
                     ) : (
                         <div className="grid gap-3">
-                            {recentWorksheets.map((ws) => (
-                                <Link
-                                    key={ws.id}
-                                    href={worksheetsIndex({
-                                        query: { worksheet: ws.id },
-                                    })}
-                                    className="flex items-center gap-4 rounded-xl border bg-card p-4 transition hover:bg-accent/50"
-                                    prefetch
-                                >
-                                    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-accent/80">
-                                        <ClipboardList className="size-4 text-accent-foreground" />
-                                    </div>
-                                    <div className="flex min-w-0 flex-col gap-0.5">
-                                        <span className="truncate text-sm font-medium">
-                                            {ws.topic}
-                                        </span>
-                                        <span className="truncate text-xs text-muted-foreground">
-                                            {ws.discipline}
-                                        </span>
-                                    </div>
-                                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                                        {new Date(ws.created_at).toLocaleDateString('pt-BR')}
-                                    </span>
-                                </Link>
-                            ))}
-                            <Button asChild variant="ghost" size="sm" className="mt-1 self-start">
-                                <Link href={worksheetsCreate()} prefetch>
-                                    <Plus className="mr-1 size-4" />
-                                    Nova lista
-                                </Link>
-                            </Button>
-                        </div>
-                    )}
-                </div>
+                            {recentActivity.map((item) => {
+                                const Icon = item.type === 'worksheet' ? ClipboardList : Brain;
+                                const href = item.type === 'worksheet'
+                                    ? worksheetsShow(item.id)
+                                    : summariesShow(item.id);
+                                const typeLabel = item.type === 'worksheet' ? 'Lista' : 'Resumo';
 
-                {/* Recent summaries */}
-                <div className="flex flex-col gap-6">
-                    <div className="flex items-center justify-between">
-                        <h2 className="text-lg font-semibold">
-                            Seus resumos
-                        </h2>
-                        <Button asChild variant="outline" size="sm">
-                            <Link href={summariesIndex()} prefetch>
-                                Ver todos
-                            </Link>
-                        </Button>
-                    </div>
-
-                    {summaryCount === 0 ? (
-                        <div className="flex flex-col items-center gap-4 rounded-2xl border border-dashed bg-card p-10 text-center">
-                            <div className="flex size-14 items-center justify-center rounded-2xl bg-muted">
-                                <Brain className="size-7 text-muted-foreground" />
-                            </div>
-                            <div className="flex flex-col gap-1">
-                                <p className="text-sm font-semibold">
-                                    Nenhum resumo ainda
-                                </p>
-                                <p className="text-xs text-muted-foreground">
-                                    Crie seu primeiro resumo de estudo com IA.
-                                </p>
-                            </div>
-                            <Button asChild size="sm">
-                                <Link href={summariesCreate()} prefetch>
-                                    <Plus className="mr-1 size-4" />
-                                    Criar primeiro resumo
-                                </Link>
-                            </Button>
-                        </div>
-                    ) : (
-                        <div className="grid gap-3">
-                            {recentSummaries.map((s) => (
-                                <Link
-                                    key={s.id}
-                                    href={summariesIndex({
-                                        query: { summary: s.id },
-                                    })}
-                                    className="flex items-center gap-4 rounded-xl border bg-card p-4 transition hover:bg-accent/50"
-                                    prefetch
-                                >
-                                    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-accent/80">
-                                        <Brain className="size-4 text-accent-foreground" />
-                                    </div>
-                                    <div className="flex min-w-0 flex-col gap-0.5">
-                                        <span className="truncate text-sm font-medium">
-                                            {s.title}
+                                return (
+                                    <Link
+                                        key={`${item.type}-${item.id}`}
+                                        href={href}
+                                        className="flex items-center gap-4 rounded-xl border bg-card p-4 transition hover:bg-accent/50"
+                                        prefetch
+                                    >
+                                        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-accent/80">
+                                            <Icon className="size-4 text-accent-foreground" />
+                                        </div>
+                                        <div className="flex min-w-0 flex-col gap-0.5">
+                                            <span className="truncate text-sm font-medium">
+                                                {item.title}
+                                            </span>
+                                            <span className="truncate text-xs text-muted-foreground">
+                                                {item.discipline}
+                                            </span>
+                                        </div>
+                                        <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                                            {typeLabel}
                                         </span>
-                                        <span className="truncate text-xs text-muted-foreground">
-                                            {s.discipline}
+                                        <span className="shrink-0 text-xs text-muted-foreground">
+                                            {new Date(item.created_at).toLocaleDateString('pt-BR')}
                                         </span>
-                                    </div>
-                                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                                        {new Date(s.created_at).toLocaleDateString('pt-BR')}
-                                    </span>
-                                </Link>
-                            ))}
-                            <Button asChild variant="ghost" size="sm" className="mt-1 self-start">
-                                <Link href={summariesCreate()} prefetch>
-                                    <Plus className="mr-1 size-4" />
-                                    Novo resumo
-                                </Link>
-                            </Button>
+                                    </Link>
+                                );
+                            })}
+                            <div className="flex gap-2 mt-1">
+                                <Button asChild variant="ghost" size="sm">
+                                    <Link href={worksheetsCreate()} prefetch>
+                                        <Plus className="mr-1 size-4" />
+                                        Nova lista
+                                    </Link>
+                                </Button>
+                                <Button asChild variant="ghost" size="sm">
+                                    <Link href={summariesCreate()} prefetch>
+                                        <Plus className="mr-1 size-4" />
+                                        Novo resumo
+                                    </Link>
+                                </Button>
+                            </div>
                         </div>
                     )}
                 </div>

--- a/resources/js/pages/summaries/index.tsx
+++ b/resources/js/pages/summaries/index.tsx
@@ -1,276 +1,136 @@
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
 import AppLayout from '@/layouts/app-layout';
-import { click as summariesShareClick } from '@/routes/summaries/share';
-import { create as summariesCreate, index as summariesIndex } from '@/routes/summaries';
+import { create as summariesCreate, index as summariesIndex, show as summariesShow } from '@/routes/summaries';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link, router } from '@inertiajs/react';
-import { useState } from 'react';
+import { Head, Link } from '@inertiajs/react';
 
-type Summary = {
+type SummaryItem = {
     id: number;
     title: string;
     discipline: string;
     topic: string;
     source_file_name?: string | null;
-    page_range_start?: number | null;
-    page_range_end?: number | null;
-    total_pages?: number | null;
-    content?: string | null;
-    share_url?: string | null;
-    share_link_copies_count?: number;
-    share_link_visits_count?: number;
     created_at: string;
 };
 
-type SummariesPageProps = {
-    summary?: Summary | null;
+type PaginatedSummaries = {
+    data: SummaryItem[];
+    current_page: number;
+    last_page: number;
+    next_page_url: string | null;
+    prev_page_url: string | null;
 };
 
-const formatCreatedAt = (value: string): string => {
-    const date = new Date(value);
+type SummariesIndexProps = {
+    summaries: PaginatedSummaries;
+};
 
+const formatDate = (value: string): string => {
+    const date = new Date(value);
     if (Number.isNaN(date.getTime())) {
         return value;
     }
-
     return new Intl.DateTimeFormat('pt-BR', {
         dateStyle: 'medium',
-        timeStyle: 'short',
     }).format(date);
 };
 
-export default function SummariesIndexPage({ summary }: SummariesPageProps) {
-    const [isShareCopied, setIsShareCopied] = useState(false);
-    const [isCopied, setIsCopied] = useState(false);
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Resumos',
+        href: summariesIndex().url,
+    },
+];
 
-    const canShare = Boolean(summary?.share_url);
-    const canCopy = Boolean(summary?.content);
-
-    const breadcrumbs: BreadcrumbItem[] = [
-        {
-            title: 'Resumos',
-            href: summariesIndex().url,
-        },
-    ];
-
-    const handleShare = () => {
-        if (!summary?.share_url) {
-            return;
-        }
-
-        navigator.clipboard.writeText(summary.share_url).then(() => {
-            setIsShareCopied(true);
-            setTimeout(() => setIsShareCopied(false), 2500);
-
-            router.post(
-                summariesShareClick(summary.id).url,
-                {},
-                { preserveScroll: true, preserveState: true },
-            );
-        });
-    };
-
-    const handleCopy = () => {
-        if (!summary?.content) {
-            return;
-        }
-
-        navigator.clipboard.writeText(summary.content).then(() => {
-            setIsCopied(true);
-            setTimeout(() => setIsCopied(false), 2500);
-        });
-    };
-
-    const handlePrint = () => {
-        window.print();
-    };
-
-    const handleDelete = () => {
-        if (!summary) {
-            return;
-        }
-
-        if (!window.confirm('Deseja remover este resumo?')) {
-            return;
-        }
-
-        router.delete(
-            summariesIndex().url.replace(/\/?$/, `/${summary.id}`),
-            { preserveScroll: true },
-        );
-    };
-
-    const pageRangeLabel =
-        summary?.page_range_start && summary?.page_range_end
-            ? `Páginas ${summary.page_range_start}–${summary.page_range_end}`
-            : summary?.total_pages
-              ? `${summary.total_pages} páginas (documento inteiro)`
-              : null;
+export default function SummariesIndexPage({ summaries }: SummariesIndexProps) {
+    const items = summaries.data;
+    const hasItems = items.length > 0;
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
-            <Head title={summary ? summary.title : 'Resumos'} />
+            <Head title="Resumos" />
 
-            {/* Print-only view */}
-            {summary && (
-                <div className="hidden print:block">
-                    <div className="mb-4 border-b pb-4">
-                        <h1 className="text-xl font-bold">{summary.title}</h1>
-                        <p className="text-sm text-gray-600">
-                            {summary.discipline} - {summary.topic}
-                        </p>
-                        {pageRangeLabel && (
-                            <p className="text-sm text-gray-500">
-                                {pageRangeLabel}
-                            </p>
-                        )}
-                    </div>
-                    <pre className="whitespace-pre-wrap text-sm leading-relaxed">
-                        {summary.content}
-                    </pre>
+            <div className="flex h-full flex-col gap-6 p-4 sm:p-6">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-semibold tracking-tight">
+                        Resumos
+                    </h1>
+                    <Button asChild size="sm">
+                        <Link href={summariesCreate()} prefetch>
+                            Novo resumo
+                        </Link>
+                    </Button>
                 </div>
-            )}
 
-            <div className="no-print flex h-full flex-col gap-4 overflow-x-auto p-4">
-                <Card>
-                    <CardHeader className="gap-2">
-                        <CardTitle>
-                            {summary
-                                ? summary.title
-                                : 'Nenhum resumo selecionado'}
-                        </CardTitle>
-                        <CardDescription className="text-sm">
-                            {summary
-                                ? 'Revise o resumo gerado e compartilhe.'
-                                : 'Crie um novo resumo para visualizar aqui.'}
-                        </CardDescription>
-                        {summary && (
-                            <div className="flex flex-col gap-2">
-                                <div className="flex flex-wrap gap-2">
-                                    <Button
-                                        type="button"
-                                        size="sm"
-                                        onClick={handleShare}
-                                        disabled={!canShare}
-                                    >
-                                        {isShareCopied
-                                            ? 'Link copiado!'
-                                            : 'Copiar link de compartilhamento'}
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        size="sm"
-                                        onClick={handlePrint}
-                                    >
-                                        Imprimir / PDF
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        size="sm"
-                                        onClick={handleCopy}
-                                        disabled={!canCopy}
-                                    >
-                                        {isCopied ? 'Copiado!' : 'Copiar resumo'}
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant="destructive"
-                                        size="sm"
-                                        onClick={handleDelete}
-                                    >
-                                        Excluir
-                                    </Button>
-                                </div>
-                                <p className="text-xs text-muted-foreground">
-                                    {isShareCopied
-                                        ? 'Link pronto para compartilhar.'
-                                        : 'Use o link compartilhável para enviar o resumo sem exigir login.'}
-                                </p>
-                            </div>
-                        )}
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                        {summary ? (
-                            <>
-                                <div className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-2 sm:gap-3">
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Disciplina:
-                                        </span>{' '}
-                                        {summary.discipline}
+                {hasItems ? (
+                    <>
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {items.map((s) => (
+                                <Link
+                                    key={s.id}
+                                    href={summariesShow(s.id)}
+                                    className="group flex flex-col gap-3 rounded-xl border bg-card p-5 shadow-xs transition hover:-translate-y-0.5 hover:shadow-md"
+                                    prefetch
+                                >
+                                    <div className="flex flex-col gap-1">
+                                        <h3 className="line-clamp-1 text-sm font-semibold">
+                                            {s.title}
+                                        </h3>
+                                        <p className="line-clamp-1 text-xs text-muted-foreground">
+                                            {s.discipline} - {s.topic}
+                                        </p>
                                     </div>
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Tópico:
-                                        </span>{' '}
-                                        {summary.topic}
-                                    </div>
-                                    {summary.source_file_name && (
-                                        <div>
-                                            <span className="font-medium text-foreground">
-                                                Arquivo:
-                                            </span>{' '}
-                                            {summary.source_file_name}
-                                        </div>
+                                    {s.source_file_name && (
+                                        <span className="line-clamp-1 text-xs text-muted-foreground">
+                                            {s.source_file_name}
+                                        </span>
                                     )}
-                                    {pageRangeLabel && (
-                                        <div>
-                                            <span className="font-medium text-foreground">
-                                                Intervalo:
-                                            </span>{' '}
-                                            {pageRangeLabel}
-                                        </div>
-                                    )}
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Compartilhamentos:
-                                        </span>{' '}
-                                        {summary.share_link_copies_count ?? 0}
-                                    </div>
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Aberturas do link:
-                                        </span>{' '}
-                                        {summary.share_link_visits_count ?? 0}
-                                    </div>
-                                    <div className="sm:col-span-2">
-                                        <span className="font-medium text-foreground">
-                                            Criado em:
-                                        </span>{' '}
-                                        {formatCreatedAt(summary.created_at)}
-                                    </div>
-                                </div>
-                                <div className="rounded-lg border bg-muted/60 px-4 py-3 text-sm leading-relaxed text-foreground">
-                                    <pre className="whitespace-pre-wrap">
-                                        {summary.content ??
-                                            'Nenhum conteúdo gerado para este resumo.'}
-                                    </pre>
-                                </div>
-                            </>
-                        ) : (
-                            <div className="flex items-center justify-between rounded-lg border border-dashed px-4 py-3 text-sm text-muted-foreground">
-                                <span>
-                                    Crie um resumo para visualizá-lo aqui.
+                                    <span className="mt-auto text-xs text-muted-foreground">
+                                        {formatDate(s.created_at)}
+                                    </span>
+                                </Link>
+                            ))}
+                        </div>
+
+                        {summaries.last_page > 1 && (
+                            <div className="flex items-center justify-center gap-2">
+                                {summaries.prev_page_url && (
+                                    <Button asChild variant="outline" size="sm">
+                                        <Link href={summaries.prev_page_url} prefetch>
+                                            Anterior
+                                        </Link>
+                                    </Button>
+                                )}
+                                <span className="text-sm text-muted-foreground">
+                                    Página {summaries.current_page} de {summaries.last_page}
                                 </span>
-                                <Button asChild variant="secondary" size="sm">
-                                    <Link href={summariesCreate()}>
-                                        Novo resumo
-                                    </Link>
-                                </Button>
+                                {summaries.next_page_url && (
+                                    <Button asChild variant="outline" size="sm">
+                                        <Link href={summaries.next_page_url} prefetch>
+                                            Próxima
+                                        </Link>
+                                    </Button>
+                                )}
                             </div>
                         )}
-                    </CardContent>
-                </Card>
+                    </>
+                ) : (
+                    <div className="flex flex-col items-center gap-4 rounded-2xl border border-dashed bg-card p-10 text-center">
+                        <div className="flex flex-col gap-1">
+                            <p className="text-sm font-semibold">
+                                Nenhum resumo ainda
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                                Crie seu primeiro resumo de estudo com IA.
+                            </p>
+                        </div>
+                        <Button asChild size="sm">
+                            <Link href={summariesCreate()} prefetch>
+                                Criar primeiro resumo
+                            </Link>
+                        </Button>
+                    </div>
+                )}
             </div>
         </AppLayout>
     );

--- a/resources/js/pages/summaries/show.tsx
+++ b/resources/js/pages/summaries/show.tsx
@@ -1,0 +1,250 @@
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import AppLayout from '@/layouts/app-layout';
+import { click as summariesShareClick } from '@/routes/summaries/share';
+import { index as summariesIndex, show as summariesShow, destroy as summariesDestroy } from '@/routes/summaries';
+import { type BreadcrumbItem } from '@/types';
+import { Head, router } from '@inertiajs/react';
+import { useState } from 'react';
+
+type Summary = {
+    id: number;
+    title: string;
+    discipline: string;
+    topic: string;
+    source_file_name?: string | null;
+    page_range_start?: number | null;
+    page_range_end?: number | null;
+    total_pages?: number | null;
+    content?: string | null;
+    share_url?: string | null;
+    share_link_copies_count?: number;
+    share_link_visits_count?: number;
+    created_at: string;
+};
+
+type SummaryShowProps = {
+    summary: Summary;
+};
+
+const formatCreatedAt = (value: string): string => {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return new Intl.DateTimeFormat('pt-BR', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(date);
+};
+
+export default function SummaryShowPage({ summary }: SummaryShowProps) {
+    const [isShareCopied, setIsShareCopied] = useState(false);
+    const [isCopied, setIsCopied] = useState(false);
+
+    const canShare = Boolean(summary.share_url);
+    const canCopy = Boolean(summary.content);
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        {
+            title: 'Resumos',
+            href: summariesIndex().url,
+        },
+        {
+            title: summary.title,
+            href: summariesShow(summary.id).url,
+        },
+    ];
+
+    const handleShare = () => {
+        if (!summary.share_url) {
+            return;
+        }
+
+        navigator.clipboard.writeText(summary.share_url).then(() => {
+            setIsShareCopied(true);
+            setTimeout(() => setIsShareCopied(false), 2500);
+
+            router.post(
+                summariesShareClick(summary.id).url,
+                {},
+                { preserveScroll: true, preserveState: true },
+            );
+        });
+    };
+
+    const handleCopy = () => {
+        if (!summary.content) {
+            return;
+        }
+
+        navigator.clipboard.writeText(summary.content).then(() => {
+            setIsCopied(true);
+            setTimeout(() => setIsCopied(false), 2500);
+        });
+    };
+
+    const handlePrint = () => {
+        window.print();
+    };
+
+    const handleDelete = () => {
+        if (!window.confirm('Deseja remover este resumo?')) {
+            return;
+        }
+
+        router.delete(summariesDestroy(summary.id).url, {
+            preserveScroll: true,
+        });
+    };
+
+    const pageRangeLabel =
+        summary.page_range_start && summary.page_range_end
+            ? `Páginas ${summary.page_range_start}–${summary.page_range_end}`
+            : summary.total_pages
+              ? `${summary.total_pages} páginas (documento inteiro)`
+              : null;
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={summary.title} />
+
+            {/* Print-only view */}
+            <div className="hidden print:block">
+                <div className="mb-4 border-b pb-4">
+                    <h1 className="text-xl font-bold">{summary.title}</h1>
+                    <p className="text-sm text-gray-600">
+                        {summary.discipline} - {summary.topic}
+                    </p>
+                    {pageRangeLabel && (
+                        <p className="text-sm text-gray-500">
+                            {pageRangeLabel}
+                        </p>
+                    )}
+                </div>
+                <pre className="whitespace-pre-wrap text-sm leading-relaxed">
+                    {summary.content}
+                </pre>
+            </div>
+
+            <div className="no-print flex h-full flex-col gap-4 overflow-x-auto p-4">
+                <Card>
+                    <CardHeader className="gap-2">
+                        <CardTitle>{summary.title}</CardTitle>
+                        <CardDescription className="text-sm">
+                            Revise o resumo gerado e compartilhe.
+                        </CardDescription>
+                        <div className="flex flex-col gap-2">
+                            <div className="flex flex-wrap gap-2">
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    onClick={handleShare}
+                                    disabled={!canShare}
+                                >
+                                    {isShareCopied
+                                        ? 'Link copiado!'
+                                        : 'Copiar link de compartilhamento'}
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={handlePrint}
+                                >
+                                    Imprimir / PDF
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={handleCopy}
+                                    disabled={!canCopy}
+                                >
+                                    {isCopied ? 'Copiado!' : 'Copiar resumo'}
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="destructive"
+                                    size="sm"
+                                    onClick={handleDelete}
+                                >
+                                    Excluir
+                                </Button>
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                                {isShareCopied
+                                    ? 'Link pronto para compartilhar.'
+                                    : 'Use o link compartilhável para enviar o resumo sem exigir login.'}
+                            </p>
+                        </div>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-2 sm:gap-3">
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Disciplina:
+                                </span>{' '}
+                                {summary.discipline}
+                            </div>
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Tópico:
+                                </span>{' '}
+                                {summary.topic}
+                            </div>
+                            {summary.source_file_name && (
+                                <div>
+                                    <span className="font-medium text-foreground">
+                                        Arquivo:
+                                    </span>{' '}
+                                    {summary.source_file_name}
+                                </div>
+                            )}
+                            {pageRangeLabel && (
+                                <div>
+                                    <span className="font-medium text-foreground">
+                                        Intervalo:
+                                    </span>{' '}
+                                    {pageRangeLabel}
+                                </div>
+                            )}
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Compartilhamentos:
+                                </span>{' '}
+                                {summary.share_link_copies_count ?? 0}
+                            </div>
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Aberturas do link:
+                                </span>{' '}
+                                {summary.share_link_visits_count ?? 0}
+                            </div>
+                            <div className="sm:col-span-2">
+                                <span className="font-medium text-foreground">
+                                    Criado em:
+                                </span>{' '}
+                                {formatCreatedAt(summary.created_at)}
+                            </div>
+                        </div>
+                        <div className="rounded-lg border bg-muted/60 px-4 py-3 text-sm leading-relaxed text-foreground">
+                            <pre className="whitespace-pre-wrap">
+                                {summary.content ??
+                                    'Nenhum conteúdo gerado para este resumo.'}
+                            </pre>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/worksheets/index.tsx
+++ b/resources/js/pages/worksheets/index.tsx
@@ -1,1086 +1,156 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
 import AppLayout from '@/layouts/app-layout';
-import { click as worksheetsShareClick } from '@/routes/worksheets/share';
-import { create as worksheetsCreate, index as worksheetsIndex } from '@/routes/worksheets';
+import { create as worksheetsCreate, index as worksheetsIndex, show as worksheetsShow } from '@/routes/worksheets';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link, router } from '@inertiajs/react';
-import { useState } from 'react';
+import { Head, Link } from '@inertiajs/react';
 
-type Worksheet = {
+type WorksheetItem = {
     id: number;
-    education_level: string;
     discipline: string;
     topic: string;
     difficulty: string;
-    goal: string;
+    education_level: string;
     question_count: number;
-    exercise_types?: string[] | null;
-    answer_style?: string | null;
-    grade_year?: string | null;
-    semester_period?: string | null;
-    notes?: string | null;
-    content?: string | null;
-    share_url?: string | null;
-    share_link_copies_count?: number;
-    share_link_visits_count?: number;
     created_at: string;
 };
 
-type WorksheetQuestion = {
-    number: number;
-    type?: string;
-    prompt: string;
-    options: string[];
-    statements: string[];
-    details: string[];
+type PaginatedWorksheets = {
+    data: WorksheetItem[];
+    current_page: number;
+    last_page: number;
+    next_page_url: string | null;
+    prev_page_url: string | null;
 };
 
-type WorksheetAnswerKeyItem = {
-    number: number;
-    answer: string;
-    explanation?: string;
+type WorksheetsIndexProps = {
+    worksheets: PaginatedWorksheets;
 };
 
-type WorksheetContent = {
-    summary: string[];
-    questions: WorksheetQuestion[];
-    answerKey: WorksheetAnswerKeyItem[];
+const difficultyColors: Record<string, string> = {
+    facil: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    intermediario: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    dificil: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
 };
 
-type WorksheetsPageProps = {
-    worksheet?: Worksheet | null;
+const difficultyLabels: Record<string, string> = {
+    facil: 'Fácil',
+    intermediario: 'Intermediário',
+    dificil: 'Difícil',
 };
 
-const educationLevelLabels: Record<string, string> = {
-    escola: 'Escola',
-    faculdade: 'Faculdade',
-    'pos-graduacao': 'Pós-graduação',
-    mestrado: 'Mestrado',
-    doutorado: 'Doutorado',
-    outro: 'Outro',
-    outros: 'Outro',
+const formatDate = (value: string): string => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return new Intl.DateTimeFormat('pt-BR', {
+        dateStyle: 'medium',
+    }).format(date);
 };
 
-const exerciseTypeLabels: Record<string, string> = {
-    multipla_escolha: 'Múltipla escolha',
-    discursivo: 'Discursivo',
-    verdadeiro_falso: 'Verdadeiro/Falso',
-    problemas_praticos: 'Problemas práticos',
-};
-
-const answerStyleLabels: Record<string, string> = {
-    simples: 'Resposta simples',
-    explicacao: 'Resposta com explicação',
-};
-
-const questionTypeLabels: Record<string, string> = {
-    multipla_escolha: 'Múltipla escolha',
-    verdadeiro_falso: 'Verdadeiro/Falso',
-    discursivo: 'Discursivo',
-    problemas_praticos: 'Problemas práticos',
-};
-
-const normalizeText = (value: string): string =>
-    value
-        .toLowerCase()
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .trim();
-
-const normalizeQuestionType = (value?: string | null): string | undefined => {
-    if (!value) {
-        return undefined;
-    }
-
-    const trimmed = value.trim();
-    if (!trimmed) {
-        return undefined;
-    }
-
-    const normalized = normalizeText(trimmed);
-
-    if (normalized.includes('verdadeiro')) {
-        return 'verdadeiro_falso';
-    }
-
-    if (normalized.includes('multipla')) {
-        return 'multipla_escolha';
-    }
-
-    if (normalized.includes('discurs')) {
-        return 'discursivo';
-    }
-
-    if (normalized.includes('problema')) {
-        return 'problemas_praticos';
-    }
-
-    const slug = normalized
-        .replace(/[^a-z0-9]+/g, '_')
-        .replace(/^_+|_+$/g, '');
-
-    if (questionTypeLabels[slug]) {
-        return slug;
-    }
-
-    return trimmed;
-};
-
-const inferQuestionType = (
-    question: WorksheetQuestion,
-    exerciseTypes?: string[] | null,
-): string | undefined => {
-    const explicitType = normalizeQuestionType(question.type);
-    if (explicitType) {
-        return explicitType;
-    }
-
-    if (question.statements.length > 0) {
-        return 'verdadeiro_falso';
-    }
-
-    if (question.options.length > 0) {
-        return 'multipla_escolha';
-    }
-
-    const openEndedTypes = (exerciseTypes ?? []).filter(
-        (type) => type === 'discursivo' || type === 'problemas_praticos',
-    );
-
-    if (openEndedTypes.length === 1) {
-        return openEndedTypes[0];
-    }
-
-    if (openEndedTypes.length > 1) {
-        const text = normalizeText(
-            [question.prompt, ...question.details].filter(Boolean).join(' '),
-        );
-        const practicalHints = [
-            'problema',
-            'problemas',
-            'situacao',
-            'cenario',
-            'contexto',
-            'dados',
-            'tarefa',
-            'aplicacao',
-            'aplique',
-            'resolva',
-            'realista',
-        ];
-
-        return practicalHints.some((hint) => text.includes(hint))
-            ? 'problemas_praticos'
-            : 'discursivo';
-    }
-
-    if (exerciseTypes?.length === 1) {
-        return exerciseTypes[0];
-    }
-
-    return undefined;
-};
-
-const resolveQuestionTypes = (
-    questions: WorksheetQuestion[],
-    exerciseTypes?: string[] | null,
-): WorksheetQuestion[] =>
-    questions.map((question) => ({
-        ...question,
-        type: inferQuestionType(question, exerciseTypes),
-    }));
-
-const parseWorksheetContent = (
-    content: string | null | undefined,
-    exerciseTypes?: string[] | null,
-): WorksheetContent | null => {
-    if (!content) {
-        return null;
-    }
-
-    const trimmed = content.trim();
-    if (trimmed.startsWith('{')) {
-        try {
-            const parsed = JSON.parse(content);
-
-            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-                return null;
-            }
-
-            const summary =
-                typeof parsed.summary === 'string'
-                    ? parsed.summary
-                          .split(/\r?\n/)
-                          .map((line: string) => line.trim())
-                          .filter(Boolean)
-                    : [];
-            const questions = Array.isArray(parsed.questions)
-                ? parsed.questions.map((question: Record<string, unknown>, index: number) => ({
-                      number:
-                          typeof question?.number === 'number'
-                              ? (question.number as number)
-                              : index + 1,
-                      type:
-                          typeof question?.type === 'string'
-                              ? (question.type as string)
-                              : undefined,
-                      prompt:
-                          typeof question?.prompt === 'string'
-                              ? (question.prompt as string)
-                              : '',
-                      options: Array.isArray(question?.options)
-                          ? question.options.filter((option) => typeof option === 'string')
-                          : [],
-                      statements: Array.isArray(question?.statements)
-                          ? question.statements.filter(
-                                (statement) => typeof statement === 'string',
-                            )
-                          : [],
-                      details: [],
-                  }))
-                : [];
-            const answerKey = Array.isArray(parsed.answer_key)
-                ? parsed.answer_key.map((item: Record<string, unknown>, index: number) => ({
-                      number:
-                          typeof item?.number === 'number'
-                              ? (item.number as number)
-                              : index + 1,
-                      answer:
-                          typeof item?.answer === 'string'
-                              ? (item.answer as string)
-                              : '',
-                      explanation:
-                          typeof item?.explanation === 'string'
-                              ? (item.explanation as string)
-                              : undefined,
-                  }))
-                : [];
-
-            return {
-                summary,
-                questions: resolveQuestionTypes(questions, exerciseTypes),
-                answerKey,
-            };
-        } catch {
-            return null;
-        }
-    }
-
-    const lines = content.split(/\r?\n/).map((line) => line.trimEnd());
-    const normalized = (line: string) => line.trim().toLowerCase();
-    const normalizedHeader = (line: string) =>
-        normalized(line).replace(/[:\s-–—]+$/, '');
-    const summaryHeader = ['resumo'];
-    const questionsHeader = ['questoes', 'questões'];
-    const answerHeader = ['gabarito', 'resposta', 'respostas'];
-    const isHeader = (line: string, targets: string[]) => {
-        const header = normalizedHeader(line);
-
-        return targets.some((target) => header.startsWith(target));
-    };
-    const findHeaderIndex = (targets: string[]) =>
-        lines.findIndex((line) => isHeader(line, targets));
-
-    const summaryIndex = findHeaderIndex(summaryHeader);
-    const questionsIndex = findHeaderIndex(questionsHeader);
-    const answerIndex = findHeaderIndex(answerHeader);
-
-    if (summaryIndex === -1 && questionsIndex === -1 && answerIndex === -1) {
-        return null;
-    }
-
-    const sectionLines = (start: number, end: number) => {
-        if (start === -1) {
-            return [];
-        }
-
-        const sectionEnd = end === -1 ? lines.length : end;
-        return lines.slice(start + 1, sectionEnd).filter((line) => line.trim() !== '');
-    };
-
-    const nextIndex = (current: number) =>
-        [summaryIndex, questionsIndex, answerIndex]
-            .filter((index) => index > current)
-            .sort((a, b) => a - b)[0] ?? -1;
-
-    const summaryLines = sectionLines(summaryIndex, nextIndex(summaryIndex)).map((line) =>
-        line.replace(/^-+\s*/, '').trim(),
-    );
-    const questionLines = sectionLines(questionsIndex, nextIndex(questionsIndex));
-    const answerLines = sectionLines(answerIndex, nextIndex(answerIndex));
-
-    const questions: WorksheetQuestion[] = [];
-    let currentQuestion: WorksheetQuestion | null = null;
-
-    for (const line of questionLines) {
-        const trimmedLine = line.trim();
-        const questionMatch = trimmedLine.match(/^(\d+)[.)]\s*(?:\(([^)]+)\)\s*)?(.*)$/);
-
-        if (questionMatch) {
-            if (currentQuestion) {
-                questions.push(currentQuestion);
-            }
-
-            currentQuestion = {
-                number: Number(questionMatch[1]),
-                type: questionMatch[2]?.trim() || undefined,
-                prompt: questionMatch[3]?.trim() || '',
-                options: [],
-                statements: [],
-                details: [],
-            };
-            continue;
-        }
-
-        if (!currentQuestion) {
-            continue;
-        }
-
-        if (/^[a-e]\)\s+/i.test(trimmedLine)) {
-            currentQuestion.options.push(trimmedLine);
-            continue;
-        }
-
-        if (trimmedLine.startsWith('(   )')) {
-            currentQuestion.statements.push(trimmedLine);
-            continue;
-        }
-
-        currentQuestion.details.push(trimmedLine);
-    }
-
-    if (currentQuestion) {
-        questions.push(currentQuestion);
-    }
-
-    const answerKey: WorksheetAnswerKeyItem[] = [];
-    let currentAnswer: WorksheetAnswerKeyItem | null = null;
-
-    for (const [index, line] of answerLines.entries()) {
-        const trimmedLine = line.trim();
-        const match = trimmedLine.match(/^[-*]?\s*(\d+)\s*[.)-:]\s*(.+)$/);
-
-        if (!match) {
-            if (currentAnswer) {
-                const extra = trimmedLine
-                    .replace(/^(explicacao|explicação)\s*:\s*/i, '')
-                    .replace(/^[-–—]\s*/, '')
-                    .trim();
-                if (extra) {
-                    currentAnswer.explanation = currentAnswer.explanation
-                        ? `${currentAnswer.explanation} ${extra}`
-                        : extra;
-                }
-            }
-
-            continue;
-        }
-
-        let answer = match[2].trim();
-        let explanation = '';
-        const parts = answer.split(/\s[-–—]\s/);
-
-        if (parts.length > 1) {
-            answer = parts[0]?.trim() ?? '';
-            explanation = parts.slice(1).join(' - ').trim();
-        } else {
-            const parenthetical = answer.match(/^(.*)\((.+)\)$/);
-            if (parenthetical) {
-                answer = parenthetical[1]?.trim() ?? '';
-                explanation = parenthetical[2]?.trim() ?? '';
-            }
-        }
-
-        currentAnswer = {
-            number: Number(match[1]) || index + 1,
-            answer,
-            explanation: explanation || undefined,
-        };
-        answerKey.push(currentAnswer);
-    }
-
-    return {
-        summary: summaryLines.filter(Boolean),
-        questions: resolveQuestionTypes(questions, exerciseTypes),
-        answerKey,
-    };
-};
-
-const copyToClipboard = async (value: string): Promise<boolean> => {
-    try {
-        if (navigator.clipboard?.writeText) {
-            await navigator.clipboard.writeText(value);
-            return true;
-        }
-
-        const textarea = document.createElement('textarea');
-        textarea.value = value;
-        textarea.style.position = 'fixed';
-        textarea.style.opacity = '0';
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand('copy');
-        document.body.removeChild(textarea);
-
-        return true;
-    } catch {
-        return false;
-    }
-};
-
-export default function WorksheetsPage({
-    worksheet = null,
-}: WorksheetsPageProps) {
-    const [isCopied, setIsCopied] = useState(false);
-    const [isShareCopied, setIsShareCopied] = useState(false);
-    const educationLevelLabel = worksheet
-        ? (educationLevelLabels[worksheet.education_level] ??
-              worksheet.education_level)
-        : '';
-    const exerciseTypesLabel = worksheet?.exercise_types?.length
-        ? worksheet.exercise_types
-              .map((type) => exerciseTypeLabels[type] ?? type)
-              .join(', ')
-        : '';
-    const answerStyleLabel = worksheet?.answer_style
-        ? answerStyleLabels[worksheet.answer_style] ?? worksheet.answer_style
-        : '';
-    const worksheetContent = parseWorksheetContent(
-        worksheet?.content,
-        worksheet?.exercise_types,
-    );
-    const summary = worksheetContent?.summary ?? [];
-    const questions = worksheetContent?.questions ?? [];
-    const answerKey = worksheetContent?.answerKey ?? [];
-    const hasStructuredContent = Boolean(
-        worksheetContent && (summary.length || questions.length || answerKey.length),
-    );
-    const copyText = worksheet?.content ?? '';
-    const canCopy = copyText.trim().length > 0;
-    const canShare = Boolean(worksheet?.share_url);
-
-    const handleCopy = async () => {
-        if (!canCopy) {
-            return;
-        }
-
-        const copied = await copyToClipboard(copyText);
-
-        if (copied) {
-            setIsCopied(true);
-            window.setTimeout(() => setIsCopied(false), 2000);
-        } else {
-            setIsCopied(false);
-        }
-    };
-
-    const handleShare = () => {
-        if (!worksheet?.share_url) {
-            return;
-        }
-
-        router.post(worksheetsShareClick(worksheet.id).url, {}, {
-            preserveScroll: true,
-            preserveState: true,
-            onSuccess: async () => {
-                const copied = await copyToClipboard(worksheet.share_url ?? '');
-
-                if (!copied) {
-                    setIsShareCopied(false);
-                    return;
-                }
-
-                setIsShareCopied(true);
-                window.setTimeout(() => setIsShareCopied(false), 2000);
-            },
-            onError: () => {
-                setIsShareCopied(false);
-            },
-        });
-    };
-
-    const handlePrint = () => {
-        if (!worksheet) {
-            return;
-        }
-
-        window.print();
-    };
-
-    const breadcrumbs: BreadcrumbItem[] = [
-        {
-            title: 'Fichas de estudo',
-            href: worksheetsIndex().url,
-        },
-    ];
-
-    if (worksheet) {
-        breadcrumbs.push({
-            title: worksheet.topic,
-            href: worksheetsIndex({
-                query: { worksheet: worksheet.id },
-            }).url,
-        });
-    }
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Listas de exercícios',
+        href: worksheetsIndex().url,
+    },
+];
+
+export default function WorksheetsIndexPage({ worksheets }: WorksheetsIndexProps) {
+    const items = worksheets.data;
+    const hasItems = items.length > 0;
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
-            <Head title={worksheet ? worksheet.topic : 'Fichas de estudo'} />
-            <style>{`
-                .print-only {
-                    display: none;
-                }
+            <Head title="Listas de exercícios" />
 
-                @media print {
-                    @page {
-                        margin: 14mm 16mm;
-                    }
+            <div className="flex h-full flex-col gap-6 p-4 sm:p-6">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-xl font-semibold tracking-tight">
+                        Listas de exercícios
+                    </h1>
+                    <Button asChild size="sm">
+                        <Link href={worksheetsCreate()} prefetch>
+                            Nova lista
+                        </Link>
+                    </Button>
+                </div>
 
-                    body {
-                        print-color-adjust: exact;
-                        -webkit-print-color-adjust: exact;
-                        background: white;
-                    }
-
-                    header {
-                        display: none !important;
-                    }
-
-                    [data-slot="sidebar"],
-                    [data-slot="sidebar-rail"],
-                    [data-slot="sidebar-trigger"],
-                    [data-slot="sidebar-header"],
-                    [data-slot="sidebar-footer"],
-                    [data-slot="sidebar-content"],
-                    [data-slot="sidebar-menu"] {
-                        display: none !important;
-                    }
-
-                    .no-print {
-                        display: none !important;
-                    }
-
-                    .print-only {
-                        display: block !important;
-                    }
-
-                    .print-page {
-                        color: #0f172a;
-                        font-family: "Iowan Old Style", "Palatino Linotype",
-                            "Book Antiqua", Palatino, serif;
-                        font-size: 11pt;
-                        line-height: 1.55;
-                        max-width: 180mm;
-                        margin: 0 auto;
-                    }
-
-                    .print-header {
-                        border-bottom: 1px solid #e2e8f0;
-                        padding-bottom: 8pt;
-                        margin-bottom: 10pt;
-                    }
-
-                    .print-title {
-                        font-size: 18pt;
-                        font-weight: 700;
-                    }
-
-                    .print-subtitle {
-                        color: #475569;
-                        font-size: 11pt;
-                        margin-top: 2pt;
-                    }
-
-                    .print-meta {
-                        display: flex;
-                        flex-wrap: wrap;
-                        gap: 10pt;
-                        margin-top: 6pt;
-                        color: #64748b;
-                        font-size: 10pt;
-                    }
-
-                    .print-section {
-                        margin-top: 14pt;
-                    }
-
-                    .print-section-title {
-                        font-size: 12pt;
-                        font-weight: 600;
-                        letter-spacing: 0.2pt;
-                        text-transform: uppercase;
-                        margin-bottom: 8pt;
-                    }
-
-                    .print-list {
-                        margin-left: 16pt;
-                    }
-
-                    .print-question {
-                        display: grid;
-                        grid-template-columns: 22pt 1fr;
-                        column-gap: 8pt;
-                        margin-top: 10pt;
-                        break-inside: avoid;
-                    }
-
-                    .print-question-number {
-                        font-weight: 700;
-                    }
-
-                    .print-question-text {
-                        font-weight: 500;
-                    }
-
-                    .print-detail,
-                    .print-option,
-                    .print-statement {
-                        margin-left: 12pt;
-                        margin-top: 4pt;
-                    }
-                }
-            `}</style>
-
-            {worksheet && (
-                <div className="print-only">
-                    <div className="print-page">
-                        <div className="print-header">
-                            <div className="print-title">
-                                Ficha de estudo - {worksheet.topic}
-                            </div>
-                            <div className="print-subtitle">
-                                {worksheet.discipline}
-                            </div>
-                            <div className="print-meta">
-                                {educationLevelLabel && (
-                                    <span>{educationLevelLabel}</span>
-                                )}
-                                {worksheet.grade_year && (
-                                    <span>Série/Ano: {worksheet.grade_year}</span>
-                                )}
-                                <span>{worksheet.question_count} questões</span>
-                            </div>
+                {hasItems ? (
+                    <>
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {items.map((ws) => (
+                                <Link
+                                    key={ws.id}
+                                    href={worksheetsShow(ws.id)}
+                                    className="group flex flex-col gap-3 rounded-xl border bg-card p-5 shadow-xs transition hover:-translate-y-0.5 hover:shadow-md"
+                                    prefetch
+                                >
+                                    <div className="flex flex-col gap-1">
+                                        <h3 className="line-clamp-1 text-sm font-semibold">
+                                            {ws.topic}
+                                        </h3>
+                                        <p className="line-clamp-1 text-xs text-muted-foreground">
+                                            {ws.discipline}
+                                        </p>
+                                    </div>
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <Badge
+                                            variant="outline"
+                                            className={difficultyColors[ws.difficulty] ?? ''}
+                                        >
+                                            {difficultyLabels[ws.difficulty] ?? ws.difficulty}
+                                        </Badge>
+                                        <span className="text-xs text-muted-foreground">
+                                            {ws.question_count} questões
+                                        </span>
+                                    </div>
+                                    <span className="mt-auto text-xs text-muted-foreground">
+                                        {formatDate(ws.created_at)}
+                                    </span>
+                                </Link>
+                            ))}
                         </div>
 
-                        {hasStructuredContent ? (
-                            <>
-                                {questions.length > 0 && (
-                                    <section className="print-section">
-                                        <div className="print-section-title">
-                                            Lista de exercícios
-                                        </div>
-                                        <div>
-                                            {questions.map(
-                                                (question, index) => {
-                                                    const number =
-                                                        question.number ??
-                                                        index + 1;
-
-                                                    return (
-                                                        <div
-                                                            key={`print-question-${number}-${index}`}
-                                                            className="print-question"
-                                                        >
-                                                            <div className="print-question-number">
-                                                                {number}.
-                                                            </div>
-                                                            <div>
-                                                                <div className="print-question-text">
-                                                                    {question.prompt}
-                                                                </div>
-                                                                {question.details
-                                                                    .length > 0 && (
-                                                                    <div>
-                                                                        {question.details.map(
-                                                                            (
-                                                                                detail,
-                                                                                detailIndex,
-                                                                            ) => (
-                                                                                <div
-                                                                                    key={`print-detail-${number}-${detailIndex}`}
-                                                                                    className="print-detail"
-                                                                                >
-                                                                                    {detail}
-                                                                                </div>
-                                                                            ),
-                                                                        )}
-                                                                    </div>
-                                                                )}
-                                                                {question.options
-                                                                    .length > 0 && (
-                                                                    <div>
-                                                                        {question.options.map(
-                                                                            (
-                                                                                option,
-                                                                                optionIndex,
-                                                                            ) => (
-                                                                                <div
-                                                                                    key={`print-option-${number}-${optionIndex}`}
-                                                                                    className="print-option"
-                                                                                >
-                                                                                    {option}
-                                                                                </div>
-                                                                            ),
-                                                                        )}
-                                                                    </div>
-                                                                )}
-                                                                {question.statements
-                                                                    .length > 0 && (
-                                                                    <div>
-                                                                        {question.statements.map(
-                                                                            (
-                                                                                statement,
-                                                                                statementIndex,
-                                                                            ) => (
-                                                                                <div
-                                                                                    key={`print-statement-${number}-${statementIndex}`}
-                                                                                    className="print-statement"
-                                                                                >
-                                                                                    {statement}
-                                                                                </div>
-                                                                            ),
-                                                                        )}
-                                                                    </div>
-                                                                )}
-                                                            </div>
-                                                        </div>
-                                                    );
-                                                },
-                                            )}
-                                        </div>
-                                    </section>
+                        {worksheets.last_page > 1 && (
+                            <div className="flex items-center justify-center gap-2">
+                                {worksheets.prev_page_url && (
+                                    <Button asChild variant="outline" size="sm">
+                                        <Link href={worksheets.prev_page_url} prefetch>
+                                            Anterior
+                                        </Link>
+                                    </Button>
                                 )}
-                            </>
-                        ) : (
-                            <pre className="whitespace-pre-wrap text-sm">
-                                {worksheet.content ??
-                                    'Nenhum conteúdo gerado para esta ficha.'}
-                            </pre>
+                                <span className="text-sm text-muted-foreground">
+                                    Página {worksheets.current_page} de {worksheets.last_page}
+                                </span>
+                                {worksheets.next_page_url && (
+                                    <Button asChild variant="outline" size="sm">
+                                        <Link href={worksheets.next_page_url} prefetch>
+                                            Próxima
+                                        </Link>
+                                    </Button>
+                                )}
+                            </div>
                         )}
+                    </>
+                ) : (
+                    <div className="flex flex-col items-center gap-4 rounded-2xl border border-dashed bg-card p-10 text-center">
+                        <div className="flex flex-col gap-1">
+                            <p className="text-sm font-semibold">
+                                Nenhuma lista ainda
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                                Crie sua primeira lista de exercícios com IA.
+                            </p>
+                        </div>
+                        <Button asChild size="sm">
+                            <Link href={worksheetsCreate()} prefetch>
+                                Criar primeira lista
+                            </Link>
+                        </Button>
                     </div>
-                </div>
-            )}
-
-            <div className="no-print flex h-full flex-col gap-4 overflow-x-auto p-4">
-                <Card>
-                    <CardHeader className="gap-2">
-                        <CardTitle>
-                            {worksheet
-                                ? `${worksheet.discipline} - ${worksheet.topic}`
-                                : 'Nenhuma ficha selecionada'}
-                        </CardTitle>
-                        <CardDescription className="text-sm">
-                            {worksheet
-                                ? 'Revise a ficha gerada e compartilhe com o aluno.'
-                                : 'Crie uma nova ficha para visualizar aqui.'}
-                        </CardDescription>
-                        {worksheet && (
-                            <div className="flex flex-col gap-2">
-                                <div className="flex flex-wrap gap-2">
-                                    <Button type="button" size="sm" onClick={handleShare} disabled={!canShare}>
-                                        {isShareCopied ? 'Link copiado!' : 'Copiar link para aluno'}
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        size="sm"
-                                        onClick={handlePrint}
-                                    >
-                                        Imprimir / PDF
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        size="sm"
-                                        onClick={handleCopy}
-                                        disabled={!canCopy}
-                                    >
-                                        {isCopied ? 'Copiado!' : 'Copiar lista'}
-                                    </Button>
-                                </div>
-                                <p className="text-xs text-muted-foreground">
-                                    {isShareCopied
-                                        ? 'Link pronto para compartilhar com o aluno.'
-                                        : 'Use o link compartilhável para enviar a ficha sem exigir login.'}
-                                </p>
-                            </div>
-                        )}
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                        {worksheet ? (
-                            <>
-                                <div className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-2 sm:gap-3">
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Nível:
-                                        </span>{' '}
-                                        {educationLevelLabel}
-                                    </div>
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Objetivo:
-                                        </span>{' '}
-                                        {worksheet.goal}
-                                    </div>
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Dificuldade:
-                                        </span>{' '}
-                                        {worksheet.difficulty}
-                                    </div>
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Questões:
-                                        </span>{' '}
-                                        {worksheet.question_count}
-                                    </div>
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Compartilhamentos:
-                                        </span>{' '}
-                                        {worksheet.share_link_copies_count ?? 0}
-                                    </div>
-                                    <div>
-                                        <span className="font-medium text-foreground">
-                                            Aberturas do link:
-                                        </span>{' '}
-                                        {worksheet.share_link_visits_count ?? 0}
-                                    </div>
-                                    {answerStyleLabel && (
-                                        <div>
-                                            <span className="font-medium text-foreground">
-                                                Gabarito:
-                                            </span>{' '}
-                                            {answerStyleLabel}
-                                        </div>
-                                    )}
-                                    {exerciseTypesLabel && (
-                                        <div className="sm:col-span-2">
-                                            <span className="font-medium text-foreground">
-                                                Tipos de exercícios:
-                                            </span>{' '}
-                                            {exerciseTypesLabel}
-                                        </div>
-                                    )}
-                                    {worksheet.grade_year && (
-                                        <div>
-                                            <span className="font-medium text-foreground">
-                                                Série/Ano:
-                                            </span>{' '}
-                                            {worksheet.grade_year}
-                                        </div>
-                                    )}
-                                    {worksheet.semester_period && (
-                                        <div>
-                                            <span className="font-medium text-foreground">
-                                                Período:
-                                            </span>{' '}
-                                            {worksheet.semester_period}
-                                        </div>
-                                    )}
-                                    {worksheet.notes && (
-                                        <div className="sm:col-span-2">
-                                            <span className="font-medium text-foreground">
-                                                Observações:
-                                            </span>{' '}
-                                            {worksheet.notes}
-                                        </div>
-                                    )}
-                                </div>
-                                <div className="rounded-lg border bg-muted/60 px-4 py-3 text-sm leading-relaxed text-foreground">
-                                    {hasStructuredContent ? (
-                                        <div className="flex flex-col gap-6">
-                                            {summary.length > 0 && (
-                                                <div className="flex flex-col gap-2">
-                                                    <div className="text-sm font-semibold text-foreground">
-                                                        Resumo
-                                                    </div>
-                                                    <div className="rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
-                                                        <ul className="flex list-disc flex-col gap-1 pl-5">
-                                                            {summary.map((line, index) => (
-                                                                <li key={`summary-${index}`}>
-                                                                    {line}
-                                                                </li>
-                                                            ))}
-                                                        </ul>
-                                                    </div>
-                                                </div>
-                                            )}
-                                            {questions.length > 0 && (
-                                                <div className="flex flex-col gap-3">
-                                                    <div className="flex items-center justify-between">
-                                                        <div className="text-sm font-semibold text-foreground">
-                                                            Questões
-                                                        </div>
-                                                        <div className="text-xs text-muted-foreground">
-                                                            {questions.length}{' '}
-                                                            itens
-                                                        </div>
-                                                    </div>
-                                                    <div className="flex flex-col gap-3">
-                                                        {questions.map(
-                                                            (question, index) => {
-                                                                const number =
-                                                                    question.number ??
-                                                                    index + 1;
-                                                                const typeLabel =
-                                                                    question.type
-                                                                        ? questionTypeLabels[
-                                                                              question.type
-                                                                          ] ??
-                                                                          question.type
-                                                                        : '';
-
-                                                                return (
-                                                                    <div
-                                                                        key={`${number}-${index}`}
-                                                                        className="flex flex-col gap-2 rounded-lg border bg-background px-4 py-3 text-sm"
-                                                                    >
-                                                                        <div className="flex flex-wrap items-center gap-2">
-                                                                            <span className="font-semibold text-foreground">
-                                                                                Questão{' '}
-                                                                                {number}
-                                                                            </span>
-                                                                            {typeLabel && (
-                                                                                <Badge
-                                                                                    variant="secondary"
-                                                                                    className="text-[11px]"
-                                                                                >
-                                                                                    {typeLabel}
-                                                                                </Badge>
-                                                                            )}
-                                                                        </div>
-                                                                        {question.prompt && (
-                                                                            <p className="text-foreground">
-                                                                                {question.prompt}
-                                                                            </p>
-                                                                        )}
-                                                                        {question.details
-                                                                            .length > 0 && (
-                                                                            <div className="flex flex-col gap-1 text-muted-foreground">
-                                                                                {question.details.map(
-                                                                                    (
-                                                                                        detail,
-                                                                                        detailIndex,
-                                                                                    ) => (
-                                                                                        <p
-                                                                                            key={`${number}-detail-${detailIndex}`}
-                                                                                        >
-                                                                                            {detail}
-                                                                                        </p>
-                                                                                    ),
-                                                                                )}
-                                                                            </div>
-                                                                        )}
-                                                                        {question.options.length >
-                                                                            0 && (
-                                                                            <ul className="flex flex-col gap-1 text-muted-foreground">
-                                                                                {question.options.map(
-                                                                                    (
-                                                                                        option,
-                                                                                        optionIndex,
-                                                                                    ) => (
-                                                                                        <li
-                                                                                            key={`${number}-option-${optionIndex}`}
-                                                                                        >
-                                                                                            {option}
-                                                                                        </li>
-                                                                                    ),
-                                                                                )}
-                                                                            </ul>
-                                                                        )}
-                                                                        {question.statements
-                                                                            .length > 0 && (
-                                                                            <ul className="flex flex-col gap-1 text-muted-foreground">
-                                                                                {question.statements.map(
-                                                                                    (
-                                                                                        statement,
-                                                                                        statementIndex,
-                                                                                    ) => (
-                                                                                        <li
-                                                                                            key={`${number}-statement-${statementIndex}`}
-                                                                                        >
-                                                                                            {statement}
-                                                                                        </li>
-                                                                                    ),
-                                                                                )}
-                                                                            </ul>
-                                                                        )}
-                                                                    </div>
-                                                                );
-                                                            },
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            )}
-                                            {answerKey.length > 0 && (
-                                                <div className="flex flex-col gap-3">
-                                                    <div className="text-sm font-semibold text-foreground">
-                                                        Gabarito
-                                                    </div>
-                                                    <div className="grid gap-2 sm:grid-cols-2">
-                                                        {answerKey.map(
-                                                            (item, index) => {
-                                                                const number =
-                                                                    item.number ??
-                                                                    index + 1;
-
-                                                                return (
-                                                                    <div
-                                                                        key={`${number}-${index}`}
-                                                                        className="flex flex-col gap-1 rounded-md border bg-background px-3 py-2"
-                                                                    >
-                                                                        <div className="text-xs font-semibold text-muted-foreground">
-                                                                            Questão{' '}
-                                                                            {number}
-                                                                        </div>
-                                                                        <div className="text-sm text-foreground">
-                                                                            {item.answer ??
-                                                                                'Resposta não informada.'}
-                                                                        </div>
-                                                                        {item.explanation && (
-                                                                            <div className="text-xs text-muted-foreground">
-                                                                                {
-                                                                                    item.explanation
-                                                                                }
-                                                                            </div>
-                                                                        )}
-                                                                    </div>
-                                                                );
-                                                            },
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            )}
-                                        </div>
-                                    ) : (
-                                        <pre className="whitespace-pre-wrap">
-                                            {worksheet.content ??
-                                                'Nenhum conteúdo gerado para esta ficha.'}
-                                        </pre>
-                                    )}
-                                </div>
-                            </>
-                        ) : (
-                            <div className="flex items-center justify-between rounded-lg border border-dashed px-4 py-3 text-sm text-muted-foreground">
-                                <span>Crie uma ficha para visualizá-la aqui.</span>
-                                <Button asChild variant="secondary" size="sm">
-                                    <Link href={worksheetsCreate()}>
-                                        Nova ficha
-                                    </Link>
-                                </Button>
-                            </div>
-                        )}
-                    </CardContent>
-                </Card>
+                )}
             </div>
         </AppLayout>
     );

--- a/resources/js/pages/worksheets/show.tsx
+++ b/resources/js/pages/worksheets/show.tsx
@@ -1,0 +1,1074 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import AppLayout from '@/layouts/app-layout';
+import { click as worksheetsShareClick } from '@/routes/worksheets/share';
+import { index as worksheetsIndex, show as worksheetsShow, destroy as worksheetsDestroy } from '@/routes/worksheets';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link, router } from '@inertiajs/react';
+import { useState } from 'react';
+
+type Worksheet = {
+    id: number;
+    education_level: string;
+    discipline: string;
+    topic: string;
+    difficulty: string;
+    goal: string;
+    question_count: number;
+    exercise_types?: string[] | null;
+    answer_style?: string | null;
+    grade_year?: string | null;
+    semester_period?: string | null;
+    notes?: string | null;
+    content?: string | null;
+    share_url?: string | null;
+    share_link_copies_count?: number;
+    share_link_visits_count?: number;
+    created_at: string;
+};
+
+type WorksheetQuestion = {
+    number: number;
+    type?: string;
+    prompt: string;
+    options: string[];
+    statements: string[];
+    details: string[];
+};
+
+type WorksheetAnswerKeyItem = {
+    number: number;
+    answer: string;
+    explanation?: string;
+};
+
+type WorksheetContent = {
+    summary: string[];
+    questions: WorksheetQuestion[];
+    answerKey: WorksheetAnswerKeyItem[];
+};
+
+type WorksheetShowProps = {
+    worksheet: Worksheet;
+};
+
+const educationLevelLabels: Record<string, string> = {
+    escola: 'Escola',
+    faculdade: 'Faculdade',
+    'pos-graduacao': 'Pós-graduação',
+    mestrado: 'Mestrado',
+    doutorado: 'Doutorado',
+    outro: 'Outro',
+    outros: 'Outro',
+};
+
+const exerciseTypeLabels: Record<string, string> = {
+    multipla_escolha: 'Múltipla escolha',
+    discursivo: 'Discursivo',
+    verdadeiro_falso: 'Verdadeiro/Falso',
+    problemas_praticos: 'Problemas práticos',
+};
+
+const answerStyleLabels: Record<string, string> = {
+    simples: 'Resposta simples',
+    explicacao: 'Resposta com explicação',
+};
+
+const questionTypeLabels: Record<string, string> = {
+    multipla_escolha: 'Múltipla escolha',
+    verdadeiro_falso: 'Verdadeiro/Falso',
+    discursivo: 'Discursivo',
+    problemas_praticos: 'Problemas práticos',
+};
+
+const normalizeText = (value: string): string =>
+    value
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .trim();
+
+const normalizeQuestionType = (value?: string | null): string | undefined => {
+    if (!value) {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+
+    const normalized = normalizeText(trimmed);
+
+    if (normalized.includes('verdadeiro')) {
+        return 'verdadeiro_falso';
+    }
+
+    if (normalized.includes('multipla')) {
+        return 'multipla_escolha';
+    }
+
+    if (normalized.includes('discurs')) {
+        return 'discursivo';
+    }
+
+    if (normalized.includes('problema')) {
+        return 'problemas_praticos';
+    }
+
+    const slug = normalized
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+
+    if (questionTypeLabels[slug]) {
+        return slug;
+    }
+
+    return trimmed;
+};
+
+const inferQuestionType = (
+    question: WorksheetQuestion,
+    exerciseTypes?: string[] | null,
+): string | undefined => {
+    const explicitType = normalizeQuestionType(question.type);
+    if (explicitType) {
+        return explicitType;
+    }
+
+    if (question.statements.length > 0) {
+        return 'verdadeiro_falso';
+    }
+
+    if (question.options.length > 0) {
+        return 'multipla_escolha';
+    }
+
+    const openEndedTypes = (exerciseTypes ?? []).filter(
+        (type) => type === 'discursivo' || type === 'problemas_praticos',
+    );
+
+    if (openEndedTypes.length === 1) {
+        return openEndedTypes[0];
+    }
+
+    if (openEndedTypes.length > 1) {
+        const text = normalizeText(
+            [question.prompt, ...question.details].filter(Boolean).join(' '),
+        );
+        const practicalHints = [
+            'problema',
+            'problemas',
+            'situacao',
+            'cenario',
+            'contexto',
+            'dados',
+            'tarefa',
+            'aplicacao',
+            'aplique',
+            'resolva',
+            'realista',
+        ];
+
+        return practicalHints.some((hint) => text.includes(hint))
+            ? 'problemas_praticos'
+            : 'discursivo';
+    }
+
+    if (exerciseTypes?.length === 1) {
+        return exerciseTypes[0];
+    }
+
+    return undefined;
+};
+
+const resolveQuestionTypes = (
+    questions: WorksheetQuestion[],
+    exerciseTypes?: string[] | null,
+): WorksheetQuestion[] =>
+    questions.map((question) => ({
+        ...question,
+        type: inferQuestionType(question, exerciseTypes),
+    }));
+
+const parseWorksheetContent = (
+    content: string | null | undefined,
+    exerciseTypes?: string[] | null,
+): WorksheetContent | null => {
+    if (!content) {
+        return null;
+    }
+
+    const trimmed = content.trim();
+    if (trimmed.startsWith('{')) {
+        try {
+            const parsed = JSON.parse(content);
+
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                return null;
+            }
+
+            const summary =
+                typeof parsed.summary === 'string'
+                    ? parsed.summary
+                          .split(/\r?\n/)
+                          .map((line: string) => line.trim())
+                          .filter(Boolean)
+                    : [];
+            const questions = Array.isArray(parsed.questions)
+                ? parsed.questions.map((question: Record<string, unknown>, index: number) => ({
+                      number:
+                          typeof question?.number === 'number'
+                              ? (question.number as number)
+                              : index + 1,
+                      type:
+                          typeof question?.type === 'string'
+                              ? (question.type as string)
+                              : undefined,
+                      prompt:
+                          typeof question?.prompt === 'string'
+                              ? (question.prompt as string)
+                              : '',
+                      options: Array.isArray(question?.options)
+                          ? question.options.filter((option) => typeof option === 'string')
+                          : [],
+                      statements: Array.isArray(question?.statements)
+                          ? question.statements.filter(
+                                (statement) => typeof statement === 'string',
+                            )
+                          : [],
+                      details: [],
+                  }))
+                : [];
+            const answerKey = Array.isArray(parsed.answer_key)
+                ? parsed.answer_key.map((item: Record<string, unknown>, index: number) => ({
+                      number:
+                          typeof item?.number === 'number'
+                              ? (item.number as number)
+                              : index + 1,
+                      answer:
+                          typeof item?.answer === 'string'
+                              ? (item.answer as string)
+                              : '',
+                      explanation:
+                          typeof item?.explanation === 'string'
+                              ? (item.explanation as string)
+                              : undefined,
+                  }))
+                : [];
+
+            return {
+                summary,
+                questions: resolveQuestionTypes(questions, exerciseTypes),
+                answerKey,
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    const lines = content.split(/\r?\n/).map((line) => line.trimEnd());
+    const normalized = (line: string) => line.trim().toLowerCase();
+    const normalizedHeader = (line: string) =>
+        normalized(line).replace(/[:\s-–—]+$/, '');
+    const summaryHeader = ['resumo'];
+    const questionsHeader = ['questoes', 'questões'];
+    const answerHeader = ['gabarito', 'resposta', 'respostas'];
+    const isHeader = (line: string, targets: string[]) => {
+        const header = normalizedHeader(line);
+
+        return targets.some((target) => header.startsWith(target));
+    };
+    const findHeaderIndex = (targets: string[]) =>
+        lines.findIndex((line) => isHeader(line, targets));
+
+    const summaryIndex = findHeaderIndex(summaryHeader);
+    const questionsIndex = findHeaderIndex(questionsHeader);
+    const answerIndex = findHeaderIndex(answerHeader);
+
+    if (summaryIndex === -1 && questionsIndex === -1 && answerIndex === -1) {
+        return null;
+    }
+
+    const sectionLines = (start: number, end: number) => {
+        if (start === -1) {
+            return [];
+        }
+
+        const sectionEnd = end === -1 ? lines.length : end;
+        return lines.slice(start + 1, sectionEnd).filter((line) => line.trim() !== '');
+    };
+
+    const nextIndex = (current: number) =>
+        [summaryIndex, questionsIndex, answerIndex]
+            .filter((index) => index > current)
+            .sort((a, b) => a - b)[0] ?? -1;
+
+    const summaryLines = sectionLines(summaryIndex, nextIndex(summaryIndex)).map((line) =>
+        line.replace(/^-+\s*/, '').trim(),
+    );
+    const questionLines = sectionLines(questionsIndex, nextIndex(questionsIndex));
+    const answerLines = sectionLines(answerIndex, nextIndex(answerIndex));
+
+    const questions: WorksheetQuestion[] = [];
+    let currentQuestion: WorksheetQuestion | null = null;
+
+    for (const line of questionLines) {
+        const trimmedLine = line.trim();
+        const questionMatch = trimmedLine.match(/^(\d+)[.)]\s*(?:\(([^)]+)\)\s*)?(.*)$/);
+
+        if (questionMatch) {
+            if (currentQuestion) {
+                questions.push(currentQuestion);
+            }
+
+            currentQuestion = {
+                number: Number(questionMatch[1]),
+                type: questionMatch[2]?.trim() || undefined,
+                prompt: questionMatch[3]?.trim() || '',
+                options: [],
+                statements: [],
+                details: [],
+            };
+            continue;
+        }
+
+        if (!currentQuestion) {
+            continue;
+        }
+
+        if (/^[a-e]\)\s+/i.test(trimmedLine)) {
+            currentQuestion.options.push(trimmedLine);
+            continue;
+        }
+
+        if (trimmedLine.startsWith('(   )')) {
+            currentQuestion.statements.push(trimmedLine);
+            continue;
+        }
+
+        currentQuestion.details.push(trimmedLine);
+    }
+
+    if (currentQuestion) {
+        questions.push(currentQuestion);
+    }
+
+    const answerKey: WorksheetAnswerKeyItem[] = [];
+    let currentAnswer: WorksheetAnswerKeyItem | null = null;
+
+    for (const [index, line] of answerLines.entries()) {
+        const trimmedLine = line.trim();
+        const match = trimmedLine.match(/^[-*]?\s*(\d+)\s*[.)-:]\s*(.+)$/);
+
+        if (!match) {
+            if (currentAnswer) {
+                const extra = trimmedLine
+                    .replace(/^(explicacao|explicação)\s*:\s*/i, '')
+                    .replace(/^[-–—]\s*/, '')
+                    .trim();
+                if (extra) {
+                    currentAnswer.explanation = currentAnswer.explanation
+                        ? `${currentAnswer.explanation} ${extra}`
+                        : extra;
+                }
+            }
+
+            continue;
+        }
+
+        let answer = match[2].trim();
+        let explanation = '';
+        const parts = answer.split(/\s[-–—]\s/);
+
+        if (parts.length > 1) {
+            answer = parts[0]?.trim() ?? '';
+            explanation = parts.slice(1).join(' - ').trim();
+        } else {
+            const parenthetical = answer.match(/^(.*)\((.+)\)$/);
+            if (parenthetical) {
+                answer = parenthetical[1]?.trim() ?? '';
+                explanation = parenthetical[2]?.trim() ?? '';
+            }
+        }
+
+        currentAnswer = {
+            number: Number(match[1]) || index + 1,
+            answer,
+            explanation: explanation || undefined,
+        };
+        answerKey.push(currentAnswer);
+    }
+
+    return {
+        summary: summaryLines.filter(Boolean),
+        questions: resolveQuestionTypes(questions, exerciseTypes),
+        answerKey,
+    };
+};
+
+const copyToClipboard = async (value: string): Promise<boolean> => {
+    try {
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(value);
+            return true;
+        }
+
+        const textarea = document.createElement('textarea');
+        textarea.value = value;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+export default function WorksheetShowPage({
+    worksheet,
+}: WorksheetShowProps) {
+    const [isCopied, setIsCopied] = useState(false);
+    const [isShareCopied, setIsShareCopied] = useState(false);
+    const educationLevelLabel =
+        educationLevelLabels[worksheet.education_level] ??
+        worksheet.education_level;
+    const exerciseTypesLabel = worksheet.exercise_types?.length
+        ? worksheet.exercise_types
+              .map((type) => exerciseTypeLabels[type] ?? type)
+              .join(', ')
+        : '';
+    const answerStyleLabel = worksheet.answer_style
+        ? answerStyleLabels[worksheet.answer_style] ?? worksheet.answer_style
+        : '';
+    const worksheetContent = parseWorksheetContent(
+        worksheet.content,
+        worksheet.exercise_types,
+    );
+    const summary = worksheetContent?.summary ?? [];
+    const questions = worksheetContent?.questions ?? [];
+    const answerKey = worksheetContent?.answerKey ?? [];
+    const hasStructuredContent = Boolean(
+        worksheetContent && (summary.length || questions.length || answerKey.length),
+    );
+    const copyText = worksheet.content ?? '';
+    const canCopy = copyText.trim().length > 0;
+    const canShare = Boolean(worksheet.share_url);
+
+    const handleCopy = async () => {
+        if (!canCopy) {
+            return;
+        }
+
+        const copied = await copyToClipboard(copyText);
+
+        if (copied) {
+            setIsCopied(true);
+            window.setTimeout(() => setIsCopied(false), 2000);
+        } else {
+            setIsCopied(false);
+        }
+    };
+
+    const handleShare = () => {
+        if (!worksheet.share_url) {
+            return;
+        }
+
+        router.post(worksheetsShareClick(worksheet.id).url, {}, {
+            preserveScroll: true,
+            preserveState: true,
+            onSuccess: async () => {
+                const copied = await copyToClipboard(worksheet.share_url ?? '');
+
+                if (!copied) {
+                    setIsShareCopied(false);
+                    return;
+                }
+
+                setIsShareCopied(true);
+                window.setTimeout(() => setIsShareCopied(false), 2000);
+            },
+            onError: () => {
+                setIsShareCopied(false);
+            },
+        });
+    };
+
+    const handlePrint = () => {
+        window.print();
+    };
+
+    const handleDelete = () => {
+        if (!window.confirm('Deseja remover esta ficha?')) {
+            return;
+        }
+
+        router.delete(worksheetsDestroy(worksheet.id).url, {
+            preserveScroll: true,
+        });
+    };
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        {
+            title: 'Listas de exercícios',
+            href: worksheetsIndex().url,
+        },
+        {
+            title: worksheet.topic,
+            href: worksheetsShow(worksheet.id).url,
+        },
+    ];
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={worksheet.topic} />
+            <style>{`
+                .print-only {
+                    display: none;
+                }
+
+                @media print {
+                    @page {
+                        margin: 14mm 16mm;
+                    }
+
+                    body {
+                        print-color-adjust: exact;
+                        -webkit-print-color-adjust: exact;
+                        background: white;
+                    }
+
+                    header {
+                        display: none !important;
+                    }
+
+                    [data-slot="sidebar"],
+                    [data-slot="sidebar-rail"],
+                    [data-slot="sidebar-trigger"],
+                    [data-slot="sidebar-header"],
+                    [data-slot="sidebar-footer"],
+                    [data-slot="sidebar-content"],
+                    [data-slot="sidebar-menu"] {
+                        display: none !important;
+                    }
+
+                    .no-print {
+                        display: none !important;
+                    }
+
+                    .print-only {
+                        display: block !important;
+                    }
+
+                    .print-page {
+                        color: #0f172a;
+                        font-family: "Iowan Old Style", "Palatino Linotype",
+                            "Book Antiqua", Palatino, serif;
+                        font-size: 11pt;
+                        line-height: 1.55;
+                        max-width: 180mm;
+                        margin: 0 auto;
+                    }
+
+                    .print-header {
+                        border-bottom: 1px solid #e2e8f0;
+                        padding-bottom: 8pt;
+                        margin-bottom: 10pt;
+                    }
+
+                    .print-title {
+                        font-size: 18pt;
+                        font-weight: 700;
+                    }
+
+                    .print-subtitle {
+                        color: #475569;
+                        font-size: 11pt;
+                        margin-top: 2pt;
+                    }
+
+                    .print-meta {
+                        display: flex;
+                        flex-wrap: wrap;
+                        gap: 10pt;
+                        margin-top: 6pt;
+                        color: #64748b;
+                        font-size: 10pt;
+                    }
+
+                    .print-section {
+                        margin-top: 14pt;
+                    }
+
+                    .print-section-title {
+                        font-size: 12pt;
+                        font-weight: 600;
+                        letter-spacing: 0.2pt;
+                        text-transform: uppercase;
+                        margin-bottom: 8pt;
+                    }
+
+                    .print-list {
+                        margin-left: 16pt;
+                    }
+
+                    .print-question {
+                        display: grid;
+                        grid-template-columns: 22pt 1fr;
+                        column-gap: 8pt;
+                        margin-top: 10pt;
+                        break-inside: avoid;
+                    }
+
+                    .print-question-number {
+                        font-weight: 700;
+                    }
+
+                    .print-question-text {
+                        font-weight: 500;
+                    }
+
+                    .print-detail,
+                    .print-option,
+                    .print-statement {
+                        margin-left: 12pt;
+                        margin-top: 4pt;
+                    }
+                }
+            `}</style>
+
+            <div className="print-only">
+                <div className="print-page">
+                    <div className="print-header">
+                        <div className="print-title">
+                            Ficha de estudo - {worksheet.topic}
+                        </div>
+                        <div className="print-subtitle">
+                            {worksheet.discipline}
+                        </div>
+                        <div className="print-meta">
+                            {educationLevelLabel && (
+                                <span>{educationLevelLabel}</span>
+                            )}
+                            {worksheet.grade_year && (
+                                <span>Série/Ano: {worksheet.grade_year}</span>
+                            )}
+                            <span>{worksheet.question_count} questões</span>
+                        </div>
+                    </div>
+
+                    {hasStructuredContent ? (
+                        <>
+                            {questions.length > 0 && (
+                                <section className="print-section">
+                                    <div className="print-section-title">
+                                        Lista de exercícios
+                                    </div>
+                                    <div>
+                                        {questions.map(
+                                            (question, index) => {
+                                                const number =
+                                                    question.number ??
+                                                    index + 1;
+
+                                                return (
+                                                    <div
+                                                        key={`print-question-${number}-${index}`}
+                                                        className="print-question"
+                                                    >
+                                                        <div className="print-question-number">
+                                                            {number}.
+                                                        </div>
+                                                        <div>
+                                                            <div className="print-question-text">
+                                                                {question.prompt}
+                                                            </div>
+                                                            {question.details
+                                                                .length > 0 && (
+                                                                <div>
+                                                                    {question.details.map(
+                                                                        (
+                                                                            detail,
+                                                                            detailIndex,
+                                                                        ) => (
+                                                                            <div
+                                                                                key={`print-detail-${number}-${detailIndex}`}
+                                                                                className="print-detail"
+                                                                            >
+                                                                                {detail}
+                                                                            </div>
+                                                                        ),
+                                                                    )}
+                                                                </div>
+                                                            )}
+                                                            {question.options
+                                                                .length > 0 && (
+                                                                <div>
+                                                                    {question.options.map(
+                                                                        (
+                                                                            option,
+                                                                            optionIndex,
+                                                                        ) => (
+                                                                            <div
+                                                                                key={`print-option-${number}-${optionIndex}`}
+                                                                                className="print-option"
+                                                                            >
+                                                                                {option}
+                                                                            </div>
+                                                                        ),
+                                                                    )}
+                                                                </div>
+                                                            )}
+                                                            {question.statements
+                                                                .length > 0 && (
+                                                                <div>
+                                                                    {question.statements.map(
+                                                                        (
+                                                                            statement,
+                                                                            statementIndex,
+                                                                        ) => (
+                                                                            <div
+                                                                                key={`print-statement-${number}-${statementIndex}`}
+                                                                                className="print-statement"
+                                                                            >
+                                                                                {statement}
+                                                                            </div>
+                                                                        ),
+                                                                    )}
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                );
+                                            },
+                                        )}
+                                    </div>
+                                </section>
+                            )}
+                        </>
+                    ) : (
+                        <pre className="whitespace-pre-wrap text-sm">
+                            {worksheet.content ??
+                                'Nenhum conteúdo gerado para esta ficha.'}
+                        </pre>
+                    )}
+                </div>
+            </div>
+
+            <div className="no-print flex h-full flex-col gap-4 overflow-x-auto p-4">
+                <Card>
+                    <CardHeader className="gap-2">
+                        <CardTitle>
+                            {worksheet.discipline} - {worksheet.topic}
+                        </CardTitle>
+                        <CardDescription className="text-sm">
+                            Revise a ficha gerada e compartilhe com o aluno.
+                        </CardDescription>
+                        <div className="flex flex-col gap-2">
+                            <div className="flex flex-wrap gap-2">
+                                <Button type="button" size="sm" onClick={handleShare} disabled={!canShare}>
+                                    {isShareCopied ? 'Link copiado!' : 'Copiar link para aluno'}
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={handlePrint}
+                                >
+                                    Imprimir / PDF
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={handleCopy}
+                                    disabled={!canCopy}
+                                >
+                                    {isCopied ? 'Copiado!' : 'Copiar lista'}
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="destructive"
+                                    size="sm"
+                                    onClick={handleDelete}
+                                >
+                                    Excluir
+                                </Button>
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                                {isShareCopied
+                                    ? 'Link pronto para compartilhar com o aluno.'
+                                    : 'Use o link compartilhável para enviar a ficha sem exigir login.'}
+                            </p>
+                        </div>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-2 sm:gap-3">
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Nível:
+                                </span>{' '}
+                                {educationLevelLabel}
+                            </div>
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Objetivo:
+                                </span>{' '}
+                                {worksheet.goal}
+                            </div>
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Dificuldade:
+                                </span>{' '}
+                                {worksheet.difficulty}
+                            </div>
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Questões:
+                                </span>{' '}
+                                {worksheet.question_count}
+                            </div>
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Compartilhamentos:
+                                </span>{' '}
+                                {worksheet.share_link_copies_count ?? 0}
+                            </div>
+                            <div>
+                                <span className="font-medium text-foreground">
+                                    Aberturas do link:
+                                </span>{' '}
+                                {worksheet.share_link_visits_count ?? 0}
+                            </div>
+                            {answerStyleLabel && (
+                                <div>
+                                    <span className="font-medium text-foreground">
+                                        Gabarito:
+                                    </span>{' '}
+                                    {answerStyleLabel}
+                                </div>
+                            )}
+                            {exerciseTypesLabel && (
+                                <div className="sm:col-span-2">
+                                    <span className="font-medium text-foreground">
+                                        Tipos de exercícios:
+                                    </span>{' '}
+                                    {exerciseTypesLabel}
+                                </div>
+                            )}
+                            {worksheet.grade_year && (
+                                <div>
+                                    <span className="font-medium text-foreground">
+                                        Série/Ano:
+                                    </span>{' '}
+                                    {worksheet.grade_year}
+                                </div>
+                            )}
+                            {worksheet.semester_period && (
+                                <div>
+                                    <span className="font-medium text-foreground">
+                                        Período:
+                                    </span>{' '}
+                                    {worksheet.semester_period}
+                                </div>
+                            )}
+                            {worksheet.notes && (
+                                <div className="sm:col-span-2">
+                                    <span className="font-medium text-foreground">
+                                        Observações:
+                                    </span>{' '}
+                                    {worksheet.notes}
+                                </div>
+                            )}
+                        </div>
+                        <div className="rounded-lg border bg-muted/60 px-4 py-3 text-sm leading-relaxed text-foreground">
+                            {hasStructuredContent ? (
+                                <div className="flex flex-col gap-6">
+                                    {summary.length > 0 && (
+                                        <div className="flex flex-col gap-2">
+                                            <div className="text-sm font-semibold text-foreground">
+                                                Resumo
+                                            </div>
+                                            <div className="rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
+                                                <ul className="flex list-disc flex-col gap-1 pl-5">
+                                                    {summary.map((line, index) => (
+                                                        <li key={`summary-${index}`}>
+                                                            {line}
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    )}
+                                    {questions.length > 0 && (
+                                        <div className="flex flex-col gap-3">
+                                            <div className="flex items-center justify-between">
+                                                <div className="text-sm font-semibold text-foreground">
+                                                    Questões
+                                                </div>
+                                                <div className="text-xs text-muted-foreground">
+                                                    {questions.length}{' '}
+                                                    itens
+                                                </div>
+                                            </div>
+                                            <div className="flex flex-col gap-3">
+                                                {questions.map(
+                                                    (question, index) => {
+                                                        const number =
+                                                            question.number ??
+                                                            index + 1;
+                                                        const typeLabel =
+                                                            question.type
+                                                                ? questionTypeLabels[
+                                                                      question.type
+                                                                  ] ??
+                                                                  question.type
+                                                                : '';
+
+                                                        return (
+                                                            <div
+                                                                key={`${number}-${index}`}
+                                                                className="flex flex-col gap-2 rounded-lg border bg-background px-4 py-3 text-sm"
+                                                            >
+                                                                <div className="flex flex-wrap items-center gap-2">
+                                                                    <span className="font-semibold text-foreground">
+                                                                        Questão{' '}
+                                                                        {number}
+                                                                    </span>
+                                                                    {typeLabel && (
+                                                                        <Badge
+                                                                            variant="secondary"
+                                                                            className="text-[11px]"
+                                                                        >
+                                                                            {typeLabel}
+                                                                        </Badge>
+                                                                    )}
+                                                                </div>
+                                                                {question.prompt && (
+                                                                    <p className="text-foreground">
+                                                                        {question.prompt}
+                                                                    </p>
+                                                                )}
+                                                                {question.details
+                                                                    .length > 0 && (
+                                                                    <div className="flex flex-col gap-1 text-muted-foreground">
+                                                                        {question.details.map(
+                                                                            (
+                                                                                detail,
+                                                                                detailIndex,
+                                                                            ) => (
+                                                                                <p
+                                                                                    key={`${number}-detail-${detailIndex}`}
+                                                                                >
+                                                                                    {detail}
+                                                                                </p>
+                                                                            ),
+                                                                        )}
+                                                                    </div>
+                                                                )}
+                                                                {question.options.length >
+                                                                    0 && (
+                                                                    <ul className="flex flex-col gap-1 text-muted-foreground">
+                                                                        {question.options.map(
+                                                                            (
+                                                                                option,
+                                                                                optionIndex,
+                                                                            ) => (
+                                                                                <li
+                                                                                    key={`${number}-option-${optionIndex}`}
+                                                                                >
+                                                                                    {option}
+                                                                                </li>
+                                                                            ),
+                                                                        )}
+                                                                    </ul>
+                                                                )}
+                                                                {question.statements
+                                                                    .length > 0 && (
+                                                                    <ul className="flex flex-col gap-1 text-muted-foreground">
+                                                                        {question.statements.map(
+                                                                            (
+                                                                                statement,
+                                                                                statementIndex,
+                                                                            ) => (
+                                                                                <li
+                                                                                    key={`${number}-statement-${statementIndex}`}
+                                                                                >
+                                                                                    {statement}
+                                                                                </li>
+                                                                            ),
+                                                                        )}
+                                                                    </ul>
+                                                                )}
+                                                            </div>
+                                                        );
+                                                    },
+                                                )}
+                                            </div>
+                                        </div>
+                                    )}
+                                    {answerKey.length > 0 && (
+                                        <div className="flex flex-col gap-3">
+                                            <div className="text-sm font-semibold text-foreground">
+                                                Gabarito
+                                            </div>
+                                            <div className="grid gap-2 sm:grid-cols-2">
+                                                {answerKey.map(
+                                                    (item, index) => {
+                                                        const number =
+                                                            item.number ??
+                                                            index + 1;
+
+                                                        return (
+                                                            <div
+                                                                key={`${number}-${index}`}
+                                                                className="flex flex-col gap-1 rounded-md border bg-background px-3 py-2"
+                                                            >
+                                                                <div className="text-xs font-semibold text-muted-foreground">
+                                                                    Questão{' '}
+                                                                    {number}
+                                                                </div>
+                                                                <div className="text-sm text-foreground">
+                                                                    {item.answer ??
+                                                                        'Resposta não informada.'}
+                                                                </div>
+                                                                {item.explanation && (
+                                                                    <div className="text-xs text-muted-foreground">
+                                                                        {
+                                                                            item.explanation
+                                                                        }
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        );
+                                                    },
+                                                )}
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            ) : (
+                                <pre className="whitespace-pre-wrap">
+                                    {worksheet.content ??
+                                        'Nenhum conteúdo gerado para esta ficha.'}
+                                </pre>
+                            )}
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -26,20 +26,6 @@ export interface SharedData {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;
-    sidebarOpen: boolean;
-    worksheetHistory?: {
-        id: number;
-        discipline: string;
-        topic: string;
-        created_at: string;
-    }[];
-    summaryHistory?: {
-        id: number;
-        title: string;
-        discipline: string;
-        topic: string;
-        created_at: string;
-    }[];
     [key: string]: unknown;
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,6 +79,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('fichas', [WorksheetController::class, 'store'])
         ->name('worksheets.store');
 
+    Route::get('fichas/{worksheet}', [WorksheetController::class, 'show'])
+        ->name('worksheets.show');
+
     Route::post('fichas/{worksheet}/compartilhar', [WorksheetController::class, 'trackShareClick'])
         ->name('worksheets.share.click');
 
@@ -96,6 +99,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::post('resumos/detectar-paginas', [SummaryController::class, 'detectPageCount'])
         ->name('summaries.detect-pages');
+
+    Route::get('resumos/{summary}', [SummaryController::class, 'show'])
+        ->name('summaries.show');
 
     Route::post('resumos/{summary}/compartilhar', [SummaryController::class, 'trackShareClick'])
         ->name('summaries.share.click');

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Models\Summary;
 use App\Models\User;
+use App\Models\Worksheet;
+use Inertia\Testing\AssertableInertia as Assert;
 
 test('guests are redirected to the login page', function () {
     $this->get(route('dashboard'))->assertRedirect(route('login'));
@@ -10,4 +13,38 @@ test('authenticated users can access the dashboard', function () {
     $this->actingAs($user = User::factory()->create());
 
     $this->get(route('dashboard'))->assertSuccessful();
+});
+
+test('dashboard shows recent activity from worksheets and summaries', function () {
+    $this->withoutVite();
+
+    $user = User::factory()->create();
+    Worksheet::factory()->for($user)->create(['topic' => 'Derivadas']);
+    Summary::factory()->for($user)->create(['title' => 'Resumo de Algebra']);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('dashboard')
+            ->where('worksheetCount', 1)
+            ->where('summaryCount', 1)
+            ->has('recentActivity', 2)
+        );
+});
+
+test('dashboard has empty recent activity for new users', function () {
+    $this->withoutVite();
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('dashboard')
+            ->where('worksheetCount', 0)
+            ->where('summaryCount', 0)
+            ->has('recentActivity', 0)
+        );
 });

--- a/tests/Feature/Summaries/SummaryTest.php
+++ b/tests/Feature/Summaries/SummaryTest.php
@@ -14,7 +14,7 @@ test('guests cannot access summary creation page', function () {
     $this->get(route('summaries.create'))->assertRedirect(route('login'));
 });
 
-test('user can view the summaries index without a selected summary', function () {
+test('user can view the summaries index with empty list', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -22,22 +22,48 @@ test('user can view the summaries index without a selected summary', function ()
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
             ->component('summaries/index')
-            ->where('summary', null)
+            ->has('summaries.data', 0)
         );
 });
 
-test('user can view the summaries index with a selected summary', function () {
+test('user can view the summaries index with paginated list', function () {
     $user = User::factory()->create();
     $summary = Summary::factory()->for($user)->create();
 
     $this->actingAs($user)
-        ->get(route('summaries.index', ['summary' => $summary->id]))
+        ->get(route('summaries.index'))
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
             ->component('summaries/index')
+            ->has('summaries.data', 1)
+            ->where('summaries.data.0.id', $summary->id)
+            ->where('summaries.data.0.title', $summary->title)
+        );
+});
+
+test('user can view a specific summary', function () {
+    $this->withoutVite();
+
+    $user = User::factory()->create();
+    $summary = Summary::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->get(route('summaries.show', $summary))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('summaries/show')
             ->where('summary.id', $summary->id)
             ->where('summary.title', $summary->title)
         );
+});
+
+test('user cannot view summaries from other users', function () {
+    $user = User::factory()->create();
+    $summary = Summary::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('summaries.show', $summary))
+        ->assertNotFound();
 });
 
 test('user can view the create summary page', function () {
@@ -78,7 +104,7 @@ test('user can create a summary with a text file', function () {
     $summary = Summary::query()->where('user_id', $user->id)->first();
 
     $response->assertRedirect(
-        route('summaries.index', ['summary' => $summary?->id])
+        route('summaries.show', ['summary' => $summary?->id])
     );
 
     expect($summary)->not()->toBeNull()
@@ -114,7 +140,7 @@ test('user cannot delete summaries from other users', function () {
     $response->assertNotFound();
 });
 
-test('history only shows summaries from the authenticated user', function () {
+test('index only shows summaries from the authenticated user', function () {
     $user = User::factory()->create();
     $summary = Summary::factory()->for($user)->create();
     Summary::factory()->create(); // Belongs to another user
@@ -123,20 +149,7 @@ test('history only shows summaries from the authenticated user', function () {
 
     $response->assertOk()->assertInertia(fn (Assert $page) => $page
         ->component('summaries/index')
-        ->where('summary.id', $summary->id)
-        ->has('summaryHistory', 1)
-        ->where('summaryHistory.0.id', $summary->id)
+        ->has('summaries.data', 1)
+        ->where('summaries.data.0.id', $summary->id)
     );
-});
-
-test('summary history is shared via inertia', function () {
-    $user = User::factory()->create();
-    Summary::factory()->for($user)->count(3)->create();
-
-    $this->actingAs($user)
-        ->get(route('summaries.index'))
-        ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
-            ->has('summaryHistory', 3)
-        );
 });

--- a/tests/Feature/Summaries/SummaryTest.php
+++ b/tests/Feature/Summaries/SummaryTest.php
@@ -103,15 +103,15 @@ test('user can create a summary with a text file', function () {
 
     $summary = Summary::query()->where('user_id', $user->id)->first();
 
-    $response->assertRedirect(
-        route('summaries.show', ['summary' => $summary?->id])
-    );
-
     expect($summary)->not()->toBeNull()
-        ->and($summary?->content)->not->toBeEmpty()
-        ->and($summary?->discipline)->toBe('Matematica')
-        ->and($summary?->topic)->toBe('Algebra')
-        ->and($summary?->source_file_name)->toBe('estudo.txt');
+        ->and($summary->content)->not->toBeEmpty()
+        ->and($summary->discipline)->toBe('Matematica')
+        ->and($summary->topic)->toBe('Algebra')
+        ->and($summary->source_file_name)->toBe('estudo.txt');
+
+    $response->assertRedirect(
+        route('summaries.show', ['summary' => $summary->id])
+    );
 });
 
 test('user can delete a summary', function () {

--- a/tests/Feature/Summaries/SummaryTest.php
+++ b/tests/Feature/Summaries/SummaryTest.php
@@ -78,6 +78,8 @@ test('user can view the create summary page', function () {
 });
 
 test('user can create a summary with a text file', function () {
+    config()->set('services.openai.api_key', 'fake-key');
+
     $user = User::factory()->create();
 
     Http::fake([

--- a/tests/Feature/Worksheets/DocumentWorksheetTest.php
+++ b/tests/Feature/Worksheets/DocumentWorksheetTest.php
@@ -43,7 +43,7 @@ test('user can create a worksheet from a txt document with inferred metadata', f
 
     $worksheet = Worksheet::query()->where('user_id', $user->id)->first();
 
-    $response->assertRedirect(route('worksheets.index', ['worksheet' => $worksheet?->id]));
+    $response->assertRedirect(route('worksheets.show', ['worksheet' => $worksheet?->id]));
 
     expect($worksheet)->not()->toBeNull()
         ->and($worksheet?->discipline)->toBe('Historia')
@@ -146,7 +146,7 @@ test('form mode still works when creation mode is omitted', function () {
 
     $worksheet = Worksheet::query()->where('user_id', $user->id)->first();
 
-    $response->assertRedirect(route('worksheets.index', ['worksheet' => $worksheet?->id]));
+    $response->assertRedirect(route('worksheets.show', ['worksheet' => $worksheet?->id]));
 
     expect($worksheet)->not->toBeNull()
         ->and($worksheet?->discipline)->toBe('Matematica')

--- a/tests/Feature/Worksheets/WorksheetShareLinkTest.php
+++ b/tests/Feature/Worksheets/WorksheetShareLinkTest.php
@@ -15,7 +15,7 @@ test('worksheet owner can register a share click', function () {
         route('worksheets.share.click', $worksheet)
     );
 
-    $response->assertRedirect(route('worksheets.index', [
+    $response->assertRedirect(route('worksheets.show', [
         'worksheet' => $worksheet->id,
     ]));
 

--- a/tests/Feature/Worksheets/WorksheetTest.php
+++ b/tests/Feature/Worksheets/WorksheetTest.php
@@ -28,7 +28,7 @@ test('user can create a worksheet and see generated content', function () {
     $worksheet = Worksheet::query()->where('user_id', $user->id)->first();
 
     $response->assertRedirect(
-        route('worksheets.index', ['worksheet' => $worksheet?->id])
+        route('worksheets.show', ['worksheet' => $worksheet?->id])
     );
 
     expect($worksheet)->not()->toBeNull()
@@ -97,7 +97,7 @@ test('exercise types accept practical problems', function () {
     $worksheet = Worksheet::query()->where('user_id', $user->id)->first();
 
     $response->assertRedirect(
-        route('worksheets.index', ['worksheet' => $worksheet?->id])
+        route('worksheets.show', ['worksheet' => $worksheet?->id])
     );
 
     expect($worksheet?->exercise_types)->toBe(['problemas_praticos']);
@@ -122,7 +122,7 @@ test('answer style can be explanation', function () {
     $worksheet = Worksheet::query()->where('user_id', $user->id)->first();
 
     $response->assertRedirect(
-        route('worksheets.index', ['worksheet' => $worksheet?->id])
+        route('worksheets.show', ['worksheet' => $worksheet?->id])
     );
 
     expect($worksheet?->answer_style)->toBe('explicacao');
@@ -172,7 +172,7 @@ test('semester period is required for college and postgraduate levels', function
     'pos-graduacao' => ['pos-graduacao'],
 ]);
 
-test('history only shows worksheets from the authenticated user', function () {
+test('index only shows worksheets from the authenticated user', function () {
     $user = User::factory()->create();
     $worksheet = Worksheet::factory()->for($user)->create([
         'exercise_types' => ['multipla_escolha', 'discursivo'],
@@ -183,14 +183,12 @@ test('history only shows worksheets from the authenticated user', function () {
 
     $response->assertOk()->assertInertia(fn (Assert $page) => $page
         ->component('worksheets/index')
-        ->where('worksheet.id', $worksheet->id)
-        ->where('worksheet.exercise_types', ['multipla_escolha', 'discursivo'])
-        ->has('worksheetHistory', 1)
-        ->where('worksheetHistory.0.id', $worksheet->id)
+        ->has('worksheets.data', 1)
+        ->where('worksheets.data.0.id', $worksheet->id)
     );
 });
 
-test('user can view the worksheets index without a selected worksheet', function () {
+test('user can view the worksheets index with empty list', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -198,9 +196,33 @@ test('user can view the worksheets index without a selected worksheet', function
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
             ->component('worksheets/index')
-            ->where('worksheet', null)
-            ->has('worksheetHistory', 0)
+            ->has('worksheets.data', 0)
         );
+});
+
+test('user can view a specific worksheet', function () {
+    $this->withoutVite();
+
+    $user = User::factory()->create();
+    $worksheet = Worksheet::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->get(route('worksheets.show', $worksheet))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('worksheets/show')
+            ->where('worksheet.id', $worksheet->id)
+            ->where('worksheet.topic', $worksheet->topic)
+        );
+});
+
+test('user cannot view worksheets from other users', function () {
+    $user = User::factory()->create();
+    $worksheet = Worksheet::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('worksheets.show', $worksheet))
+        ->assertNotFound();
 });
 
 test('user can view the create worksheet page', function () {
@@ -213,7 +235,7 @@ test('user can view the create worksheet page', function () {
         'created_at' => now()->subDay(),
         'updated_at' => now()->subDay(),
     ]);
-    $worksheet = Worksheet::factory()->for($user)->create([
+    Worksheet::factory()->for($user)->create([
         'education_level' => 'faculdade',
         'grade_year' => null,
         'semester_period' => '2o semestre',
@@ -228,10 +250,6 @@ test('user can view the create worksheet page', function () {
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
             ->component('worksheets/create')
-            ->has('worksheetHistory', 2)
-            ->where('worksheetHistory.0.id', $worksheet->id)
-            ->where('worksheetHistory.0.discipline', 'Biologia')
-            ->where('worksheetHistory.0.topic', 'Genetica')
             ->where('lastWorksheet.education_level', 'faculdade')
             ->where('lastWorksheet.grade_year', null)
             ->where('lastWorksheet.semester_period', '2o semestre')
@@ -248,7 +266,6 @@ test('create worksheet page has no last worksheet when history is empty', functi
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
             ->component('worksheets/create')
-            ->has('worksheetHistory', 0)
             ->where('lastWorksheet', null)
         );
 });


### PR DESCRIPTION
## Summary
- **Split index/show**: Worksheet and summary index pages now display a paginated card grid; full content moved to dedicated `/fichas/{id}` and `/resumos/{id}` show routes
- **Simplified sidebar**: Removed history sections with search/delete (~410 → ~140 lines), replaced with clean nav + quick-create `+` buttons — scales to N features without growing the sidebar
- **Eliminated per-request queries**: Removed `worksheetHistory`, `summaryHistory`, and `sidebarOpen` from `HandleInertiaRequests` shared data (2 fewer queries on every authenticated request)
- **Unified dashboard activity**: Merged recent worksheets and summaries into a single `recentActivity` feed with type badges and links to show pages

## Test plan
- [x] All 115 tests passing (including new show route + ownership tests)
- [x] TypeScript builds cleanly (`npm run build`)
- [x] Pint formatted (`vendor/bin/pint --dirty`)
- [x] Manual: verify card grid on `/fichas` and `/resumos` renders correctly
- [x] Manual: verify clicking a card navigates to the show page with full content
- [x] Manual: verify sidebar navigation and `+` buttons work
- [x] Manual: verify dashboard recent activity shows mixed items

🤖 Generated with [Claude Code](https://claude.com/claude-code)